### PR TITLE
Refine hero rocket scene visuals

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,7 +1,6 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
-import { lightPalette } from "../theme/brandingTheme";
 import NextLink from "next/link";
 import { routes } from "../lib/routes";
 import dynamic from "next/dynamic";
@@ -27,17 +26,15 @@ const Hero = () => {
       <HeroCanvasContainer />
       <Box
         sx={{
-          display: "none", // TEMP: hidden for scene tuning
           position: "absolute",
           inset: 0,
           zIndex: 100,
-          background: "linear-gradient(to top, rgba(10,10,26,0.85) 0%, rgba(10,10,26,0.4) 40%, transparent 70%)",
+          background: "linear-gradient(to top, rgba(32,33,36,0.85) 0%, rgba(32,33,36,0.4) 40%, transparent 70%)",
           pointerEvents: "none"
         }}
       />
       <Box
         sx={{
-          display: "none", // TEMP: hidden for scene tuning
           zIndex: 200,
           mb: { xs: "25px", md: "24px" },
           textAlign: "center"
@@ -46,16 +43,16 @@ const Hero = () => {
         <Typography
           variant="h1"
           sx={{
-            color: lightPalette.text.primary,
+            color: "#ffffff",
             textShadow: "0 2px 8px rgba(0,0,0,0.8)"
           }}
         >
-          Your next app needs AI. Let&apos;s architect it right.
+          From idea to AI product.
         </Typography>
         <Typography
           variant="h4"
           sx={{
-            color: lightPalette.text.primary,
+            color: "#ffffff",
             textShadow: "0 2px 8px rgba(0,0,0,0.8)"
           }}
         >

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -27,6 +27,7 @@ const Hero = () => {
       <HeroCanvasContainer />
       <Box
         sx={{
+          display: "none", // TEMP: hidden for scene tuning
           position: "absolute",
           inset: 0,
           zIndex: 100,
@@ -36,6 +37,7 @@ const Hero = () => {
       />
       <Box
         sx={{
+          display: "none", // TEMP: hidden for scene tuning
           zIndex: 200,
           mb: { xs: "25px", md: "24px" },
           textAlign: "center"

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,13 +1,14 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
-import Image from "next/image";
 import { lightPalette } from "../theme/brandingTheme";
 import NextLink from "next/link";
 import { routes } from "../lib/routes";
 import dynamic from "next/dynamic";
 
-const HeroAgentSpark = dynamic(() => import("./ScrollAnimation/HeroAgentSpark"), { ssr: false });
+const HeroCanvasContainer = dynamic(() => import("./ScrollAnimation/HeroCanvasContainer"), {
+  ssr: false
+});
 
 const Hero = () => {
   return (
@@ -19,10 +20,20 @@ const Hero = () => {
         justifyContent: "flex-end",
         alignItems: "center",
         flex: 1,
-        height: "calc(100vh - 150px)"
+        height: "calc(100vh - 150px)",
+        overflow: "hidden"
       }}
     >
-      <Image priority src="/images/hero.svg" alt="thexap" fill style={{ objectFit: "cover" }} />
+      <HeroCanvasContainer />
+      <Box
+        sx={{
+          position: "absolute",
+          inset: 0,
+          zIndex: 100,
+          background: "linear-gradient(to top, rgba(10,10,26,0.85) 0%, rgba(10,10,26,0.4) 40%, transparent 70%)",
+          pointerEvents: "none"
+        }}
+      />
       <Box
         sx={{
           zIndex: 200,
@@ -32,19 +43,19 @@ const Hero = () => {
       >
         <Typography
           variant="h1"
-          sx={theme => {
-            return {
-              color: theme.palette.mode === "dark" ? lightPalette.text.primary : "inherit"
-            };
+          sx={{
+            color: lightPalette.text.primary,
+            textShadow: "0 2px 8px rgba(0,0,0,0.8)"
           }}
         >
           Your next app needs AI. Let&apos;s architect it right.
         </Typography>
         <Typography
           variant="h4"
-          sx={theme => ({
-            color: theme.palette.mode === "dark" ? lightPalette.text.primary : "inherit"
-          })}
+          sx={{
+            color: lightPalette.text.primary,
+            textShadow: "0 2px 8px rgba(0,0,0,0.8)"
+          }}
         >
           Don&apos;t let AI become the most expensive experiment your product never shipped.
         </Typography>
@@ -52,7 +63,6 @@ const Hero = () => {
           SCHEDULE A MEETING
         </Button>
       </Box>
-      <HeroAgentSpark />
     </Box>
   );
 };

--- a/src/components/ScrollAnimation/HeroCanvasContainer.tsx
+++ b/src/components/ScrollAnimation/HeroCanvasContainer.tsx
@@ -1,0 +1,87 @@
+import { useRef, useEffect, useState, useCallback } from "react";
+import Box from "@mui/material/Box";
+import RocketLaunchScene from "./scenes/RocketLaunchScene";
+
+export default function HeroCanvasContainer() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState({ width: 0, height: 0 });
+  const [progress, setProgress] = useState(0);
+  const rafId = useRef(0);
+  const lastProgress = useRef(0);
+
+  // ResizeObserver for container dimensions
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry) {
+        setSize({
+          width: entry.contentRect.width,
+          height: entry.contentRect.height
+        });
+      }
+    });
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  // Custom scroll progress for the hero:
+  // progress = 0 when page just loaded (rect.top = 0)
+  // progress = 1 when hero bottom reaches viewport top
+  const updateProgress = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const rect = el.getBoundingClientRect();
+    const viewportHeight = window.innerHeight;
+    const scrollableDistance = rect.height - viewportHeight;
+
+    let rawProgress: number;
+    if (scrollableDistance <= 0) {
+      // Hero is shorter than viewport, use simpler calc
+      rawProgress = Math.max(0, -rect.top / rect.height);
+    } else {
+      rawProgress = -rect.top / scrollableDistance;
+    }
+
+    const clamped = Math.max(0, Math.min(1, rawProgress));
+
+    if (Math.abs(clamped - lastProgress.current) > 0.001) {
+      lastProgress.current = clamped;
+      setProgress(clamped);
+    }
+  }, []);
+
+  useEffect(() => {
+    const onScroll = () => {
+      cancelAnimationFrame(rafId.current);
+      rafId.current = requestAnimationFrame(updateProgress);
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    updateProgress();
+
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      cancelAnimationFrame(rafId.current);
+    };
+  }, [updateProgress]);
+
+  return (
+    <Box
+      ref={containerRef}
+      sx={{
+        position: "absolute",
+        inset: 0,
+        zIndex: 0
+      }}
+    >
+      {size.width > 0 && size.height > 0 && (
+        <RocketLaunchScene progress={progress} width={size.width} height={size.height} />
+      )}
+    </Box>
+  );
+}

--- a/src/components/ScrollAnimation/scenes/RocketLaunchScene.tsx
+++ b/src/components/ScrollAnimation/scenes/RocketLaunchScene.tsx
@@ -12,6 +12,8 @@ import {
   drawSkyline,
   drawRocket,
   drawExhaust,
+  drawSmokeBack,
+  drawSmokeFront,
   drawVignette,
   spawnParticles,
   updateParticles,
@@ -123,19 +125,22 @@ export default function RocketLaunchScene({ progress, width, height }: Props) {
       // Effective progress: whichever is higher
       const p = Math.max(scrollP, hoverProgressRef.current);
 
-      // Draw scene layers
+      // Draw scene layers (back to front)
       drawSky(ctx, w, h);
       drawStarfield(ctx, starsRef.current, timestamp, p, w);
+      drawSmokeBack(ctx, p, w, h, timestamp); // smoke behind buildings
       drawSkyline(ctx, buildingsRef.current, windowStatesRef.current, p, timestamp, w, h);
       drawRocket(ctx, p, timestamp, w, h);
 
-      // Particle system
+      // Particle system (small exhaust sparks)
       const { rocketW, rocketH, nozzleH, centerX } = dims;
       const rocketBaseY = rocketY + rocketH * 0.75 + nozzleH;
 
       spawnParticles(particlesRef.current, p, rocketBaseY, centerX, rocketW);
       updateParticles(particlesRef.current);
       drawExhaust(ctx, particlesRef.current, w);
+
+      drawSmokeFront(ctx, p, w, h, timestamp); // smoke in front of buildings
 
       // Vignette overlay (last layer)
       drawVignette(ctx, w, h);

--- a/src/components/ScrollAnimation/scenes/RocketLaunchScene.tsx
+++ b/src/components/ScrollAnimation/scenes/RocketLaunchScene.tsx
@@ -49,7 +49,7 @@ export default function RocketLaunchScene({ progress, width, height }: Props) {
     starsRef.current = generateStars(width, height);
     buildingsRef.current = generateBuildings(width, height);
 
-    const onRatio = 0.3;
+    const onRatio = 0.15;
     windowStatesRef.current = generateWindowStates(buildingsRef.current, onRatio);
     particlesRef.current = createParticlePool(width);
   }, [width, height]);
@@ -81,11 +81,11 @@ export default function RocketLaunchScene({ progress, width, height }: Props) {
       drawSky(ctx, w, h);
       drawStarfield(ctx, starsRef.current, timestamp, p, w);
       drawSkyline(ctx, buildingsRef.current, windowStatesRef.current, p, timestamp, w, h);
-      drawRocket(ctx, p, timestamp, w, h, buildingsRef.current);
+      drawRocket(ctx, p, timestamp, w, h);
 
       // Particle system
       const { rocketW, rocketH, nozzleH, centerX } = getRocketDimensions(w, h);
-      const rocketY = getRocketY(p, h, buildingsRef.current);
+      const rocketY = getRocketY(p, h);
       const rocketBaseY = rocketY + rocketH * 0.75 + nozzleH;
 
       spawnParticles(particlesRef.current, p, rocketBaseY, centerX, rocketW);
@@ -118,15 +118,20 @@ export default function RocketLaunchScene({ progress, width, height }: Props) {
 
     // Target on-ratio increases with progress
     let targetOnRatio: number;
-    if (progress < 0.3) targetOnRatio = 0.3;
-    else if (progress < 0.6) targetOnRatio = 0.3 + ((progress - 0.3) / 0.3) * 0.2;
-    else targetOnRatio = 0.5 + ((progress - 0.6) / 0.4) * 0.3;
+    if (progress < 0.3) targetOnRatio = 0.15;
+    else if (progress < 0.6) targetOnRatio = 0.15 + ((progress - 0.3) / 0.3) * 0.15;
+    else targetOnRatio = 0.3 + ((progress - 0.6) / 0.4) * 0.2;
 
     for (let i = 0; i < buildings.length; i++) {
       const b = buildings[i];
       const bStates = states[i];
       if (!bStates) continue;
-      const total = b.windowCols * b.windowRows;
+      // Total windows across all window groups
+      let total = 0;
+      for (const g of b.windowGroups) {
+        total += g.cols * g.rows;
+      }
+      if (total === 0) continue;
 
       // Toggle 2-3 random windows, biased toward the target ratio
       const toggleCount = 2 + Math.floor(Math.random() * 2);

--- a/src/components/ScrollAnimation/scenes/RocketLaunchScene.tsx
+++ b/src/components/ScrollAnimation/scenes/RocketLaunchScene.tsx
@@ -16,7 +16,9 @@ import {
   spawnParticles,
   updateParticles,
   getRocketDimensions,
-  getRocketY
+  getRocketY,
+  IGNITION_START,
+  LAUNCH_START
 } from "./rocketDrawUtils";
 
 interface Props {
@@ -118,9 +120,11 @@ export default function RocketLaunchScene({ progress, width, height }: Props) {
 
     // Target on-ratio increases with progress
     let targetOnRatio: number;
-    if (progress < 0.3) targetOnRatio = 0.15;
-    else if (progress < 0.6) targetOnRatio = 0.15 + ((progress - 0.3) / 0.3) * 0.15;
-    else targetOnRatio = 0.3 + ((progress - 0.6) / 0.4) * 0.2;
+    const ignitionRange = LAUNCH_START - IGNITION_START;
+    const launchRange = 1 - LAUNCH_START;
+    if (progress < IGNITION_START) targetOnRatio = 0.15;
+    else if (progress < LAUNCH_START) targetOnRatio = 0.15 + ((progress - IGNITION_START) / ignitionRange) * 0.15;
+    else targetOnRatio = 0.3 + ((progress - LAUNCH_START) / launchRange) * 0.2;
 
     for (let i = 0; i < buildings.length; i++) {
       const b = buildings[i];

--- a/src/components/ScrollAnimation/scenes/RocketLaunchScene.tsx
+++ b/src/components/ScrollAnimation/scenes/RocketLaunchScene.tsx
@@ -37,6 +37,8 @@ export default function RocketLaunchScene({ progress, width, height }: Props) {
   const lastFlickerRef = useRef(0);
   const sizeRef = useRef({ width: 0, height: 0 });
   const rafRef = useRef(0);
+  const mouseRef = useRef({ x: -1, y: -1 }); // -1 = not on canvas
+  const hoverProgressRef = useRef(0);
 
   // Keep progress ref in sync
   useEffect(() => {
@@ -69,15 +71,57 @@ export default function RocketLaunchScene({ progress, width, height }: Props) {
     canvas.height = height * dpr;
     ctx.scale(dpr, dpr);
 
+    // Mouse tracking for hover-to-ignite
+    const onMouseMove = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      mouseRef.current = {
+        x: e.clientX - rect.left,
+        y: e.clientY - rect.top
+      };
+    };
+    const onMouseLeave = () => {
+      mouseRef.current = { x: -1, y: -1 };
+    };
+    canvas.addEventListener("mousemove", onMouseMove);
+    canvas.addEventListener("mouseleave", onMouseLeave);
+
     const render = (timestamp: number) => {
       if (document.hidden) {
         rafRef.current = requestAnimationFrame(render);
         return;
       }
 
-      const p = progressRef.current;
+      const scrollP = progressRef.current;
       const w = sizeRef.current.width;
       const h = sizeRef.current.height;
+
+      // Hit-test mouse against rocket bounding box
+      const dims = getRocketDimensions(w, h);
+      const rocketY = getRocketY(scrollP, h);
+      const mx = mouseRef.current.x;
+      const my = mouseRef.current.y;
+      const pad = dims.rocketW * 0.8; // generous hit area around rocket
+      const isHovering =
+        mx >= 0 &&
+        mx >= dims.centerX - dims.rocketW / 2 - pad &&
+        mx <= dims.centerX + dims.rocketW / 2 + pad &&
+        my >= rocketY - pad &&
+        my <= rocketY + dims.rocketH + dims.nozzleH + pad;
+
+      // Smoothly ramp hover progress up/down
+      const hoverTarget = isHovering ? LAUNCH_START : 0;
+      const rampSpeed = 0.03; // per frame (~0.5s to full at 60fps)
+      if (hoverProgressRef.current < hoverTarget) {
+        hoverProgressRef.current = Math.min(hoverTarget, hoverProgressRef.current + rampSpeed);
+      } else if (hoverProgressRef.current > hoverTarget) {
+        hoverProgressRef.current = Math.max(hoverTarget, hoverProgressRef.current - rampSpeed * 0.5);
+      }
+
+      // Update cursor
+      canvas.style.cursor = isHovering ? "pointer" : "default";
+
+      // Effective progress: whichever is higher
+      const p = Math.max(scrollP, hoverProgressRef.current);
 
       // Draw scene layers
       drawSky(ctx, w, h);
@@ -86,8 +130,7 @@ export default function RocketLaunchScene({ progress, width, height }: Props) {
       drawRocket(ctx, p, timestamp, w, h);
 
       // Particle system
-      const { rocketW, rocketH, nozzleH, centerX } = getRocketDimensions(w, h);
-      const rocketY = getRocketY(p, h);
+      const { rocketW, rocketH, nozzleH, centerX } = dims;
       const rocketBaseY = rocketY + rocketH * 0.75 + nozzleH;
 
       spawnParticles(particlesRef.current, p, rocketBaseY, centerX, rocketW);
@@ -110,6 +153,8 @@ export default function RocketLaunchScene({ progress, width, height }: Props) {
 
     return () => {
       cancelAnimationFrame(rafRef.current);
+      canvas.removeEventListener("mousemove", onMouseMove);
+      canvas.removeEventListener("mouseleave", onMouseLeave);
     };
   }, [width, height]);
 

--- a/src/components/ScrollAnimation/scenes/RocketLaunchScene.tsx
+++ b/src/components/ScrollAnimation/scenes/RocketLaunchScene.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useRef } from "react";
+import {
+  Star,
+  Building,
+  Particle,
+  generateStars,
+  generateBuildings,
+  generateWindowStates,
+  createParticlePool,
+  drawSky,
+  drawStarfield,
+  drawSkyline,
+  drawRocket,
+  drawExhaust,
+  drawVignette,
+  spawnParticles,
+  updateParticles,
+  getRocketDimensions,
+  getRocketY
+} from "./rocketDrawUtils";
+
+interface Props {
+  progress: number;
+  width: number;
+  height: number;
+}
+
+export default function RocketLaunchScene({ progress, width, height }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const progressRef = useRef(progress);
+  const starsRef = useRef<Star[]>([]);
+  const buildingsRef = useRef<Building[]>([]);
+  const windowStatesRef = useRef<boolean[][]>([]);
+  const particlesRef = useRef<Particle[]>([]);
+  const lastFlickerRef = useRef(0);
+  const sizeRef = useRef({ width: 0, height: 0 });
+  const rafRef = useRef(0);
+
+  // Keep progress ref in sync
+  useEffect(() => {
+    progressRef.current = progress;
+  }, [progress]);
+
+  // Regenerate scene data when dimensions change
+  useEffect(() => {
+    if (width === 0 || height === 0) return;
+
+    sizeRef.current = { width, height };
+    starsRef.current = generateStars(width, height);
+    buildingsRef.current = generateBuildings(width, height);
+
+    const onRatio = 0.3;
+    windowStatesRef.current = generateWindowStates(buildingsRef.current, onRatio);
+    particlesRef.current = createParticlePool(width);
+  }, [width, height]);
+
+  // Main rAF render loop
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || width === 0 || height === 0) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    ctx.scale(dpr, dpr);
+
+    const render = (timestamp: number) => {
+      if (document.hidden) {
+        rafRef.current = requestAnimationFrame(render);
+        return;
+      }
+
+      const p = progressRef.current;
+      const w = sizeRef.current.width;
+      const h = sizeRef.current.height;
+
+      // Draw scene layers
+      drawSky(ctx, w, h);
+      drawStarfield(ctx, starsRef.current, timestamp, p, w);
+      drawSkyline(ctx, buildingsRef.current, windowStatesRef.current, p, timestamp, w, h);
+      drawRocket(ctx, p, timestamp, w, h, buildingsRef.current);
+
+      // Particle system
+      const { rocketW, rocketH, nozzleH, centerX } = getRocketDimensions(w, h);
+      const rocketY = getRocketY(p, h, buildingsRef.current);
+      const rocketBaseY = rocketY + rocketH * 0.75 + nozzleH;
+
+      spawnParticles(particlesRef.current, p, rocketBaseY, centerX, rocketW);
+      updateParticles(particlesRef.current);
+      drawExhaust(ctx, particlesRef.current, w);
+
+      // Vignette overlay (last layer)
+      drawVignette(ctx, w, h);
+
+      // Flicker windows every ~500ms
+      if (timestamp - lastFlickerRef.current > 500) {
+        lastFlickerRef.current = timestamp;
+        flickerWindows(p);
+      }
+
+      rafRef.current = requestAnimationFrame(render);
+    };
+
+    rafRef.current = requestAnimationFrame(render);
+
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, [width, height]);
+
+  function flickerWindows(progress: number) {
+    const buildings = buildingsRef.current;
+    const states = windowStatesRef.current;
+    if (!states.length) return;
+
+    // Target on-ratio increases with progress
+    let targetOnRatio: number;
+    if (progress < 0.3) targetOnRatio = 0.3;
+    else if (progress < 0.6) targetOnRatio = 0.3 + ((progress - 0.3) / 0.3) * 0.2;
+    else targetOnRatio = 0.5 + ((progress - 0.6) / 0.4) * 0.3;
+
+    for (let i = 0; i < buildings.length; i++) {
+      const b = buildings[i];
+      const bStates = states[i];
+      if (!bStates) continue;
+      const total = b.windowCols * b.windowRows;
+
+      // Toggle 2-3 random windows, biased toward the target ratio
+      const toggleCount = 2 + Math.floor(Math.random() * 2);
+      for (let t = 0; t < toggleCount; t++) {
+        const idx = Math.floor(Math.random() * total);
+        const currentOn = bStates.filter(Boolean).length / total;
+        if (currentOn < targetOnRatio) {
+          bStates[idx] = true;
+        } else if (currentOn > targetOnRatio + 0.1) {
+          bStates[idx] = false;
+        } else {
+          bStates[idx] = !bStates[idx];
+        }
+      }
+    }
+  }
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "block"
+      }}
+    />
+  );
+}

--- a/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
+++ b/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
@@ -63,15 +63,18 @@ const SKY_COLOR = "#202124";
 const PRIMARY = "#f59415";
 
 // Window colors: subtle warm tones for lit, cool grays for dark (matching SVG)
-const WINDOW_COLORS_ON = ["#e8d8b0", "#ddd0a8", "#d4c898", "#cfc090", "#e0d4b0"];
+const WINDOW_COLORS_ON = ["#9e9070", "#8a8068", "#7d7560", "#918760", "#8c8470"];
 
-const WINDOW_COLORS_OFF = ["#9da3ab", "#b3b9c2", "#b7bbc4", "#bcc1cc", "#c5cad4"];
+const WINDOW_COLORS_OFF = ["#3a3e45", "#42464d", "#4a4e55", "#383c43", "#454950"];
 
-// Building body colors: cool gray-blues, lighter = further back
-const BUILDING_COLORS_BACK = ["#e3e9f5", "#e4e9f5", "#dde2ed", "#dce2ed"];
-const BUILDING_COLORS_FRONT = ["#d7dde8", "#ccd1db", "#c5cad4"];
+// Building body colors: muted dark grays so they don't compete with the rocket
+const BUILDING_COLORS_BACK = ["#5a5e66", "#6b7078", "#4e535b", "#737980", "#636971"];
+const BUILDING_COLORS_FRONT = ["#3d4148", "#4a4f57", "#555b63", "#484d54", "#5f656d"];
 
 const ROOF_STYLES: Building["roofStyle"][] = ["flat", "peaked", "stepped", "tower"];
+
+// Counter to cycle through building colors so adjacent buildings never share a color
+let _buildingColorIndex = 0;
 
 // ── Generation Functions ──
 
@@ -127,7 +130,7 @@ function createBuilding(
   roofStyle: Building["roofStyle"]
 ): Building {
   const colors = layer === 0 ? BUILDING_COLORS_BACK : BUILDING_COLORS_FRONT;
-  const color = colors[Math.floor(Math.random() * colors.length)];
+  const color = colors[_buildingColorIndex++ % colors.length];
 
   const towerWidth = roofStyle === "tower" ? 0.15 + Math.random() * 0.15 : 0;
   const towerHeight = roofStyle === "tower" ? bHeight * (0.15 + Math.random() * 0.15) : 0;
@@ -155,6 +158,7 @@ function createBuilding(
 }
 
 export function generateBuildings(width: number, height: number): Building[] {
+  _buildingColorIndex = 0;
   const isMobile = width < 768;
   const buildings: Building[] = [];
 

--- a/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
+++ b/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
@@ -2,8 +2,8 @@
 // Idle: 0 → IGNITION_START (sputtering engine, minimal particles)
 // Ignition: IGNITION_START → LAUNCH_START (vibration, nozzle glow, moderate exhaust)
 // Launch: LAUNCH_START → 1.0 (liftoff, star streaks, full exhaust)
-export const IGNITION_START = 0.02;
-export const LAUNCH_START = 0.3;
+export const IGNITION_START = 0.01;
+export const LAUNCH_START = 0.2;
 const LAUNCH_RANGE = 0.6 - LAUNCH_START; // duration of launch phase
 const IGNITION_RANGE = LAUNCH_START - IGNITION_START; // duration of ignition phase
 
@@ -815,17 +815,17 @@ export const SMOKE_DRIFT_SPEED = 0.0001; // how fast clouds billow/drift
 export const SMOKE_GROUND_Y = 0.05; // ground level as fraction from bottom
 
 const SMOKE_COLORS_BACK = [
-  "rgba(139, 100, 50, 0.7)", // dark golden brown
-  "rgba(120, 85, 40, 0.65)",
-  "rgba(150, 110, 55, 0.6)",
-  "rgba(100, 75, 35, 0.55)"
+  "rgba(139, 100, 50, 0.9)", // dark golden brown
+  "rgba(120, 85, 40, 0.85)",
+  "rgba(150, 110, 55, 0.8)",
+  "rgba(100, 75, 35, 0.75)"
 ];
 
 const SMOKE_COLORS_FRONT = [
-  "rgba(245, 180, 80, 0.75)", // warm orange
-  "rgba(250, 195, 100, 0.7)",
-  "rgba(240, 170, 65, 0.65)",
-  "rgba(255, 200, 110, 0.6)"
+  "rgba(245, 180, 80, 0.95)", // warm orange
+  "rgba(250, 195, 100, 0.9)",
+  "rgba(240, 170, 65, 0.9)",
+  "rgba(255, 200, 110, 0.9)"
 ];
 
 interface SmokeCloud {

--- a/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
+++ b/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
@@ -3,8 +3,8 @@
 // Ignition: IGNITION_START → LAUNCH_START (vibration, nozzle glow, moderate exhaust)
 // Launch: LAUNCH_START → 1.0 (liftoff, star streaks, full exhaust)
 export const IGNITION_START = 0.02;
-export const LAUNCH_START = 0.1;
-const LAUNCH_RANGE = 1 - LAUNCH_START; // duration of launch phase
+export const LAUNCH_START = 0.3;
+const LAUNCH_RANGE = 0.6 - LAUNCH_START; // duration of launch phase
 const IGNITION_RANGE = LAUNCH_START - IGNITION_START; // duration of ignition phase
 
 // ── Data Structures ──

--- a/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
+++ b/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
@@ -1,0 +1,832 @@
+// ── Data Structures ──
+
+export interface Star {
+  x: number;
+  y: number;
+  radius: number;
+  twinkleOffset: number;
+  twinkleSpeed: number;
+}
+
+export interface Building {
+  x: number;
+  width: number;
+  height: number;
+  windowCols: number;
+  windowRows: number;
+  topStyle: "flat" | "dome" | "peak" | "stepped";
+  layer: number; // 0=back, 1=mid, 2=front
+  windowColorIndices: number[]; // pre-assigned color index per window
+}
+
+export interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  maxLife: number;
+  size: number;
+  color: string;
+}
+
+// ── Constants ──
+
+const SKY_COLOR = "#0a0a1a";
+const PRIMARY = "#f59415";
+
+const WINDOW_COLORS_ON = ["#ffd870", "#ffe8a0", "#ffcc44", "#e8c060", "#f0d080", "#ffffff"];
+
+const WINDOW_COLORS_OFF = ["#7b7a7c", "#9da3ab", "#b3b9c2", "#bcc1cc", "#c5cad4", "#505060", "#3a3a4a", "#606878"];
+
+const BUILDING_GRADIENTS: [string, string][] = [
+  ["#1a1a2e", "#12121f"], // back layer
+  ["#252540", "#1a1a30"], // mid layer
+  ["#2d2d4a", "#1e1e35"] // front layer
+];
+
+const TOP_STYLES: Building["topStyle"][] = ["flat", "dome", "peak", "stepped"];
+
+// ── Generation Functions ──
+
+export function generateStars(width: number, height: number): Star[] {
+  const isMobile = width < 768;
+  const count = isMobile ? 40 + Math.floor(Math.random() * 20) : 80 + Math.floor(Math.random() * 70);
+  const stars: Star[] = [];
+  for (let i = 0; i < count; i++) {
+    stars.push({
+      x: Math.random() * width,
+      y: Math.random() * height * 0.7,
+      radius: 0.5 + Math.random() * 1.5,
+      twinkleOffset: Math.random() * Math.PI * 2,
+      twinkleSpeed: 0.5 + Math.random() * 1.5
+    });
+  }
+  return stars;
+}
+
+export function generateBuildings(width: number, height: number): Building[] {
+  const isMobile = width < 768;
+  const count = isMobile ? 5 + Math.floor(Math.random() * 3) : 8 + Math.floor(Math.random() * 6);
+  const buildings: Building[] = [];
+  const avgWidth = width / (count * 0.7);
+
+  for (let i = 0; i < count; i++) {
+    const bWidth = avgWidth * (0.6 + Math.random() * 0.8);
+    const bHeight = height * (0.25 + Math.random() * 0.35);
+    const x = (i / count) * width - bWidth * 0.1 + Math.random() * (avgWidth * 0.3);
+    const windowCols = Math.max(3, Math.floor(bWidth / 10));
+    const windowRows = Math.max(4, Math.floor(bHeight / 12));
+    const total = windowCols * windowRows;
+
+    // Pre-assign a color index to each window for consistency across frames
+    const windowColorIndices = Array.from({ length: total }, () =>
+      Math.floor(Math.random() * WINDOW_COLORS_OFF.length)
+    );
+
+    const layer = i < count / 3 ? 0 : i < (count * 2) / 3 ? 1 : 2;
+
+    buildings.push({
+      x,
+      width: bWidth,
+      height: bHeight,
+      windowCols,
+      windowRows,
+      topStyle: TOP_STYLES[Math.floor(Math.random() * TOP_STYLES.length)],
+      layer,
+      windowColorIndices
+    });
+  }
+
+  // Sort by layer so back buildings draw first
+  buildings.sort((a, b) => a.layer - b.layer);
+  return buildings;
+}
+
+export function generateWindowStates(buildings: Building[], onRatio: number): boolean[][] {
+  return buildings.map(b => {
+    const total = b.windowCols * b.windowRows;
+    return Array.from({ length: total }, () => Math.random() < onRatio);
+  });
+}
+
+// ── Drawing Functions ──
+
+export function drawSky(ctx: CanvasRenderingContext2D, width: number, height: number) {
+  // Sky gradient: deep blue-black at top, slightly lighter at horizon
+  const grad = ctx.createLinearGradient(0, 0, 0, height);
+  grad.addColorStop(0, "#050510");
+  grad.addColorStop(0.7, SKY_COLOR);
+  grad.addColorStop(1, "#0f0f2a");
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, width, height);
+}
+
+export function drawStarfield(
+  ctx: CanvasRenderingContext2D,
+  stars: Star[],
+  time: number,
+  progress: number,
+  width: number
+) {
+  const isMobile = width < 768;
+
+  for (const star of stars) {
+    const twinkle = 0.3 + 0.7 * Math.abs(Math.sin(time * 0.001 * star.twinkleSpeed + star.twinkleOffset));
+    ctx.globalAlpha = twinkle;
+    ctx.fillStyle = "#ffffff";
+    ctx.beginPath();
+    ctx.arc(star.x, star.y, star.radius, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Phase 3: star streaks (desktop only)
+    if (!isMobile && progress > 0.6) {
+      const streakLength = ((progress - 0.6) / 0.4) * 15;
+      ctx.strokeStyle = `rgba(255, 255, 255, ${twinkle * 0.4})`;
+      ctx.lineWidth = star.radius * 0.5;
+      ctx.beginPath();
+      ctx.moveTo(star.x, star.y);
+      ctx.lineTo(star.x, star.y - streakLength);
+      ctx.stroke();
+    }
+  }
+  ctx.globalAlpha = 1;
+}
+
+// ── Building Drawing ──
+
+function drawBuildingShape(ctx: CanvasRenderingContext2D, b: Building, topY: number, baseY: number) {
+  ctx.beginPath();
+
+  switch (b.topStyle) {
+    case "dome":
+      ctx.moveTo(b.x, baseY);
+      ctx.lineTo(b.x, topY + b.width * 0.15);
+      ctx.quadraticCurveTo(b.x, topY, b.x + b.width * 0.15, topY);
+      ctx.lineTo(b.x + b.width * 0.85, topY);
+      ctx.quadraticCurveTo(b.x + b.width, topY, b.x + b.width, topY + b.width * 0.15);
+      ctx.lineTo(b.x + b.width, baseY);
+      ctx.closePath();
+      break;
+
+    case "peak": {
+      const peakH = b.height * 0.12;
+      ctx.moveTo(b.x, baseY);
+      ctx.lineTo(b.x, topY + peakH);
+      ctx.lineTo(b.x + b.width * 0.35, topY + peakH);
+      ctx.quadraticCurveTo(b.x + b.width * 0.5, topY - peakH * 0.3, b.x + b.width * 0.65, topY + peakH);
+      ctx.lineTo(b.x + b.width, topY + peakH);
+      ctx.lineTo(b.x + b.width, baseY);
+      ctx.closePath();
+      break;
+    }
+
+    case "stepped": {
+      const stepW = b.width * 0.2;
+      const stepH = b.height * 0.1;
+      ctx.moveTo(b.x, baseY);
+      ctx.lineTo(b.x, topY + stepH);
+      ctx.lineTo(b.x + stepW, topY + stepH);
+      ctx.lineTo(b.x + stepW, topY);
+      ctx.lineTo(b.x + b.width - stepW, topY);
+      ctx.lineTo(b.x + b.width - stepW, topY + stepH);
+      ctx.lineTo(b.x + b.width, topY + stepH);
+      ctx.lineTo(b.x + b.width, baseY);
+      ctx.closePath();
+      break;
+    }
+
+    default:
+      // flat with subtle rounded top corners
+      ctx.moveTo(b.x, baseY);
+      ctx.lineTo(b.x, topY + 3);
+      ctx.quadraticCurveTo(b.x, topY, b.x + 3, topY);
+      ctx.lineTo(b.x + b.width - 3, topY);
+      ctx.quadraticCurveTo(b.x + b.width, topY, b.x + b.width, topY + 3);
+      ctx.lineTo(b.x + b.width, baseY);
+      ctx.closePath();
+      break;
+  }
+}
+
+export function drawSkyline(
+  ctx: CanvasRenderingContext2D,
+  buildings: Building[],
+  windowStates: boolean[][],
+  progress: number,
+  _time: number,
+  width: number,
+  height: number
+) {
+  const baseY = height;
+  const isMobile = width < 768;
+
+  for (let i = 0; i < buildings.length; i++) {
+    const b = buildings[i];
+    const topY = baseY - b.height;
+
+    // Building body with gradient
+    const colors = BUILDING_GRADIENTS[Math.min(b.layer, 2)];
+    const grad = ctx.createLinearGradient(b.x, topY, b.x, baseY);
+    grad.addColorStop(0, colors[0]);
+    grad.addColorStop(1, colors[1]);
+
+    ctx.globalAlpha = b.layer === 0 ? 0.5 : b.layer === 1 ? 0.65 : 0.8;
+
+    drawBuildingShape(ctx, b, topY, baseY);
+    ctx.fillStyle = grad;
+    ctx.fill();
+
+    // Subtle edge highlight on front buildings
+    if (b.layer === 2) {
+      drawBuildingShape(ctx, b, topY, baseY);
+      ctx.strokeStyle = "rgba(100, 100, 140, 0.3)";
+      ctx.lineWidth = 1;
+      ctx.stroke();
+    }
+
+    ctx.globalAlpha = 1;
+
+    // Windows
+    const states = windowStates[i];
+    if (!states) continue;
+
+    const winW = Math.max(5, (b.width / (b.windowCols + 1)) * 0.5);
+    const winH = Math.max(5, (b.height / (b.windowRows + 1)) * 0.4);
+    const padX = (b.width - b.windowCols * winW) / (b.windowCols + 1);
+    const padY = (b.height - b.windowRows * winH) / (b.windowRows + 1);
+
+    for (let row = 0; row < b.windowRows; row++) {
+      for (let col = 0; col < b.windowCols; col++) {
+        const idx = row * b.windowCols + col;
+        const wx = b.x + padX + col * (winW + padX);
+        const wy = topY + padY + row * (winH + padY);
+        const isOn = states[idx];
+        const colorIdx = b.windowColorIndices[idx] ?? 0;
+
+        if (isOn) {
+          const onColorIdx = colorIdx % WINDOW_COLORS_ON.length;
+          ctx.fillStyle = WINDOW_COLORS_ON[onColorIdx];
+
+          // Glow on lit windows (desktop only)
+          if (!isMobile) {
+            ctx.shadowColor = WINDOW_COLORS_ON[onColorIdx];
+            ctx.shadowBlur = 3;
+          }
+        } else {
+          ctx.fillStyle = WINDOW_COLORS_OFF[colorIdx];
+          ctx.shadowBlur = 0;
+        }
+
+        ctx.fillRect(wx, wy, winW, winH);
+      }
+      // Reset shadow after each row for performance
+      ctx.shadowBlur = 0;
+      ctx.shadowColor = "transparent";
+    }
+  }
+
+  // Ground fog
+  const fogGrad = ctx.createLinearGradient(0, height - 30, 0, height);
+  fogGrad.addColorStop(0, "transparent");
+  fogGrad.addColorStop(1, "rgba(10, 10, 26, 0.6)");
+  ctx.fillStyle = fogGrad;
+  ctx.fillRect(0, height - 30, width, 30);
+
+  // Exhaust glow on buildings (Phase 3)
+  if (progress > 0.6) {
+    const glowIntensity = (progress - 0.6) / 0.4;
+    const rocketBaseX = width / 2;
+    const maxBH = buildings.reduce((max, b) => Math.max(max, b.height), 0);
+    const rocketBaseY = baseY - maxBH * 0.5;
+    const gradient = ctx.createRadialGradient(
+      rocketBaseX,
+      rocketBaseY,
+      0,
+      rocketBaseX,
+      rocketBaseY,
+      width * 0.4 * glowIntensity
+    );
+    gradient.addColorStop(0, `rgba(245, 148, 21, ${0.25 * glowIntensity})`);
+    gradient.addColorStop(0.5, `rgba(245, 148, 21, ${0.1 * glowIntensity})`);
+    gradient.addColorStop(1, "transparent");
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, width, height);
+  }
+}
+
+// ── Rocket Drawing ──
+
+export function getRocketDimensions(width: number, height: number) {
+  const rocketH = height * 0.5;
+  const rocketW = rocketH * 0.18;
+  const centerX = width / 2;
+  const noseH = rocketH * 0.2;
+  const bodyH = rocketH * 0.55;
+  const nozzleH = rocketH * 0.1;
+  const finH = rocketH * 0.25;
+  return { rocketH, rocketW, centerX, noseH, bodyH, nozzleH, finH };
+}
+
+export function getRocketY(progress: number, height: number, buildings: Building[]): number {
+  const maxBuildingH = buildings.reduce((max, b) => Math.max(max, b.height), 0);
+  const dims = getRocketDimensions(0, height);
+  const padHeight = 8;
+  const launchPadY = height - maxBuildingH * 0.4 - padHeight;
+  const onPadY = launchPadY - dims.rocketH;
+
+  if (progress <= 0.6) return onPadY;
+
+  // Phase 3: liftoff with easeIn
+  const t = (progress - 0.6) / 0.4;
+  const eased = t * t;
+  const targetY = -dims.rocketH - 40;
+  return onPadY + (targetY - onPadY) * eased;
+}
+
+function resetShadow(ctx: CanvasRenderingContext2D) {
+  ctx.shadowBlur = 0;
+  ctx.shadowColor = "transparent";
+  ctx.shadowOffsetX = 0;
+  ctx.shadowOffsetY = 0;
+}
+
+export function drawRocket(
+  ctx: CanvasRenderingContext2D,
+  progress: number,
+  _time: number,
+  width: number,
+  height: number,
+  buildings: Building[]
+) {
+  const dims = getRocketDimensions(width, height);
+  const { rocketH, rocketW, centerX, noseH, bodyH, nozzleH, finH } = dims;
+  const rocketY = getRocketY(progress, height, buildings);
+
+  // Phase 2 vibration
+  let offsetX = 0;
+  if (progress > 0.3 && progress <= 0.6) {
+    const intensity = (progress - 0.3) / 0.3;
+    offsetX = (Math.random() * 2 - 1) * intensity * 2;
+  }
+
+  const x = centerX + offsetX;
+  const y = rocketY;
+  const bodyTop = y + noseH;
+  const bodyBottom = bodyTop + bodyH;
+  const halfW = rocketW / 2;
+
+  // ── 1. Ambient glow behind rocket ──
+  const glowGrad = ctx.createRadialGradient(x, y + rocketH * 0.5, 0, x, y + rocketH * 0.5, rocketW * 3);
+  glowGrad.addColorStop(0, "rgba(245, 148, 21, 0.08)");
+  glowGrad.addColorStop(1, "transparent");
+  ctx.fillStyle = glowGrad;
+  ctx.fillRect(x - rocketW * 3, y, rocketW * 6, rocketH);
+
+  // ── 2. Fins (drawn behind body) ──
+  drawFin(ctx, x, bodyTop, bodyBottom, halfW, finH, -1); // left
+  drawFin(ctx, x, bodyTop, bodyBottom, halfW, finH, 1); // right
+
+  // ── 3. Engine nozzle ──
+  drawNozzle(ctx, x, bodyBottom, halfW, nozzleH, progress);
+
+  // ── 4. Body with gradient and shadow ──
+  ctx.save();
+  ctx.shadowColor = "rgba(0, 0, 0, 0.35)";
+  ctx.shadowBlur = rocketW * 0.5;
+  ctx.shadowOffsetX = rocketW * 0.08;
+  ctx.shadowOffsetY = rocketH * 0.03;
+
+  // Curved body path
+  const bodyPath = new Path2D();
+  bodyPath.moveTo(x - halfW * 0.96, bodyTop);
+  bodyPath.bezierCurveTo(
+    x - halfW * 1.04,
+    bodyTop + bodyH * 0.25,
+    x - halfW * 1.04,
+    bodyTop + bodyH * 0.75,
+    x - halfW * 0.92,
+    bodyBottom
+  );
+  bodyPath.lineTo(x + halfW * 0.92, bodyBottom);
+  bodyPath.bezierCurveTo(
+    x + halfW * 1.04,
+    bodyTop + bodyH * 0.75,
+    x + halfW * 1.04,
+    bodyTop + bodyH * 0.25,
+    x + halfW * 0.96,
+    bodyTop
+  );
+  bodyPath.closePath();
+
+  // Horizontal gradient for cylindrical lighting
+  const bodyGrad = ctx.createLinearGradient(x - halfW, bodyTop, x + halfW, bodyTop);
+  bodyGrad.addColorStop(0, "#c8c8c8");
+  bodyGrad.addColorStop(0.2, "#d8d8d8");
+  bodyGrad.addColorStop(0.45, "#f0f0f0");
+  bodyGrad.addColorStop(0.55, "#ffffff");
+  bodyGrad.addColorStop(0.8, "#e0e0e0");
+  bodyGrad.addColorStop(1, "#b8b8b8");
+  ctx.fillStyle = bodyGrad;
+  ctx.fill(bodyPath);
+  ctx.restore();
+  resetShadow(ctx);
+
+  // Warm orange overlay
+  ctx.save();
+  ctx.globalAlpha = 0.25;
+  const warmGrad = ctx.createLinearGradient(x - halfW, bodyTop, x + halfW, bodyTop);
+  warmGrad.addColorStop(0, "#f59415");
+  warmGrad.addColorStop(0.5, "#fcddb6");
+  warmGrad.addColorStop(1, "#f59415");
+  ctx.fillStyle = warmGrad;
+  ctx.fill(bodyPath);
+  ctx.restore();
+
+  // ── 5. Metal band at nose junction ──
+  const bandH = bodyH * 0.025;
+  const bandGrad = ctx.createLinearGradient(x - halfW, 0, x + halfW, 0);
+  bandGrad.addColorStop(0, "#595959");
+  bandGrad.addColorStop(0.5, "#a6a6a6");
+  bandGrad.addColorStop(1, "#595959");
+  ctx.fillStyle = bandGrad;
+  ctx.fillRect(x - halfW * 0.96, bodyTop, halfW * 1.92, bandH);
+
+  // Metal band at nozzle junction
+  ctx.fillStyle = bandGrad;
+  ctx.fillRect(x - halfW * 0.92, bodyBottom - bandH, halfW * 1.84, bandH);
+
+  // ── 6. Panel lines ──
+  ctx.strokeStyle = "rgba(150, 150, 150, 0.25)";
+  ctx.lineWidth = 0.8;
+  for (const frac of [0.3, 0.55, 0.78]) {
+    const lineY = bodyTop + bodyH * frac;
+    // Follow the barrel curve approximately
+    const bulge = frac > 0.2 && frac < 0.8 ? halfW * 1.02 : halfW * 0.95;
+    ctx.beginPath();
+    ctx.moveTo(x - bulge, lineY);
+    ctx.lineTo(x + bulge, lineY);
+    ctx.stroke();
+  }
+
+  // Vertical seam
+  ctx.strokeStyle = "rgba(180, 180, 180, 0.12)";
+  ctx.lineWidth = 0.6;
+  ctx.beginPath();
+  ctx.moveTo(x, bodyTop + bandH);
+  ctx.lineTo(x, bodyBottom - bandH);
+  ctx.stroke();
+
+  // ── 7. Window (4-layer porthole) ──
+  const winRadius = rocketW * 0.32;
+  const winCenterY = bodyTop + bodyH * 0.3;
+  drawPorthole(ctx, x, winCenterY, winRadius);
+
+  // ── 8. Nose cone (smooth bezier dome) ──
+  drawNoseCone(ctx, x, y, bodyTop, halfW, noseH);
+
+  // ── 9. Launch pad ──
+  if (progress < 0.8) {
+    const maxBuildingH = buildings.reduce((max, b) => Math.max(max, b.height), 0);
+    const padY = height - maxBuildingH * 0.4;
+    const padW = rocketW * 2.5;
+    const padGrad = ctx.createLinearGradient(centerX - padW / 2, padY, centerX + padW / 2, padY);
+    padGrad.addColorStop(0, "#3a3a4a");
+    padGrad.addColorStop(0.5, "#6a6a7a");
+    padGrad.addColorStop(1, "#3a3a4a");
+    ctx.fillStyle = padGrad;
+    ctx.fillRect(centerX - padW / 2, padY - 4, padW, 8);
+
+    // Support struts
+    ctx.strokeStyle = "#4a4a5a";
+    ctx.lineWidth = 2.5;
+    ctx.beginPath();
+    ctx.moveTo(centerX - padW / 2, padY);
+    ctx.lineTo(centerX - padW / 3, height);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(centerX + padW / 2, padY);
+    ctx.lineTo(centerX + padW / 3, height);
+    ctx.stroke();
+  }
+}
+
+function drawNoseCone(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  tipY: number,
+  baseY: number,
+  halfW: number,
+  noseH: number
+) {
+  // Smooth bezier dome
+  const nosePath = new Path2D();
+  nosePath.moveTo(x - halfW * 0.96, baseY);
+  nosePath.bezierCurveTo(x - halfW * 0.96, baseY - noseH * 0.6, x - halfW * 0.2, tipY, x, tipY);
+  nosePath.bezierCurveTo(x + halfW * 0.2, tipY, x + halfW * 0.96, baseY - noseH * 0.6, x + halfW * 0.96, baseY);
+  nosePath.closePath();
+
+  // Gradient fill
+  const noseGrad = ctx.createLinearGradient(x - halfW, tipY, x + halfW, tipY);
+  noseGrad.addColorStop(0, "#d07a10");
+  noseGrad.addColorStop(0.3, "#f59415");
+  noseGrad.addColorStop(0.55, "#fca64e");
+  noseGrad.addColorStop(0.75, "#f59415");
+  noseGrad.addColorStop(1, "#c06a08");
+
+  ctx.fillStyle = noseGrad;
+  ctx.fill(nosePath);
+
+  // Specular highlight on nose
+  ctx.save();
+  ctx.globalAlpha = 0.3;
+  const highlightPath = new Path2D();
+  const hx = x - halfW * 0.2;
+  const hy = tipY + noseH * 0.3;
+  highlightPath.moveTo(hx, hy);
+  highlightPath.bezierCurveTo(
+    hx - halfW * 0.3,
+    hy + noseH * 0.2,
+    hx - halfW * 0.15,
+    hy + noseH * 0.5,
+    hx + halfW * 0.1,
+    hy + noseH * 0.4
+  );
+  highlightPath.bezierCurveTo(hx + halfW * 0.2, hy + noseH * 0.1, hx + halfW * 0.1, hy - noseH * 0.05, hx, hy);
+  highlightPath.closePath();
+  ctx.fillStyle = "#ffffff";
+  ctx.fill(highlightPath);
+  ctx.restore();
+}
+
+function drawFin(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  bodyTop: number,
+  bodyBottom: number,
+  halfW: number,
+  finH: number,
+  side: -1 | 1 // -1 = left, 1 = right
+) {
+  ctx.save();
+  ctx.shadowColor = "rgba(0, 0, 0, 0.4)";
+  ctx.shadowBlur = 6;
+  ctx.shadowOffsetX = side * 2;
+  ctx.shadowOffsetY = 2;
+
+  const finPath = new Path2D();
+  const attachTop = bodyTop + (bodyBottom - bodyTop) * 0.55;
+  const attachBottom = bodyBottom;
+  const tipX = x + side * halfW * 1.8;
+  const tipY = bodyBottom + finH * 0.7;
+
+  finPath.moveTo(x + side * halfW * 0.9, attachTop);
+  finPath.lineTo(x + side * halfW * 0.9, attachBottom);
+  finPath.bezierCurveTo(x + side * halfW * 1.0, attachBottom + finH * 0.3, tipX - side * halfW * 0.2, tipY, tipX, tipY);
+  finPath.bezierCurveTo(
+    tipX - side * halfW * 0.1,
+    tipY - finH * 0.3,
+    x + side * halfW * 1.2,
+    attachTop + (attachBottom - attachTop) * 0.2,
+    x + side * halfW * 0.9,
+    attachTop
+  );
+  finPath.closePath();
+
+  const finGrad = ctx.createLinearGradient(x, attachTop, x + side * halfW * 1.8, tipY);
+  finGrad.addColorStop(0, "#cc2929");
+  finGrad.addColorStop(0.5, "#e04040");
+  finGrad.addColorStop(1, "#991f1f");
+  ctx.fillStyle = finGrad;
+  ctx.fill(finPath);
+
+  ctx.restore();
+  resetShadow(ctx);
+}
+
+function drawNozzle(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  bodyBottom: number,
+  halfW: number,
+  nozzleH: number,
+  progress: number
+) {
+  // Flared bell shape
+  const nozzlePath = new Path2D();
+  const topW = halfW * 0.7;
+  const bottomW = halfW * 1.0;
+
+  nozzlePath.moveTo(x - topW, bodyBottom);
+  nozzlePath.bezierCurveTo(
+    x - topW,
+    bodyBottom + nozzleH * 0.4,
+    x - bottomW * 1.1,
+    bodyBottom + nozzleH * 0.8,
+    x - bottomW,
+    bodyBottom + nozzleH
+  );
+  nozzlePath.lineTo(x + bottomW, bodyBottom + nozzleH);
+  nozzlePath.bezierCurveTo(
+    x + bottomW * 1.1,
+    bodyBottom + nozzleH * 0.8,
+    x + topW,
+    bodyBottom + nozzleH * 0.4,
+    x + topW,
+    bodyBottom
+  );
+  nozzlePath.closePath();
+
+  const nozzleGrad = ctx.createLinearGradient(x - bottomW, bodyBottom, x + bottomW, bodyBottom);
+  nozzleGrad.addColorStop(0, "#3a3a3a");
+  nozzleGrad.addColorStop(0.3, "#888888");
+  nozzleGrad.addColorStop(0.5, "#a6a6a6");
+  nozzleGrad.addColorStop(0.7, "#888888");
+  nozzleGrad.addColorStop(1, "#3a3a3a");
+  ctx.fillStyle = nozzleGrad;
+  ctx.fill(nozzlePath);
+
+  // Inner glow during ignition/launch
+  if (progress > 0.15) {
+    const glowIntensity = Math.min(1, (progress - 0.15) / 0.3);
+    const innerGlow = ctx.createRadialGradient(
+      x,
+      bodyBottom + nozzleH * 0.8,
+      0,
+      x,
+      bodyBottom + nozzleH * 0.8,
+      bottomW * 0.8
+    );
+    innerGlow.addColorStop(0, `rgba(255, 224, 78, ${0.8 * glowIntensity})`);
+    innerGlow.addColorStop(0.4, `rgba(245, 148, 21, ${0.6 * glowIntensity})`);
+    innerGlow.addColorStop(0.7, `rgba(204, 41, 41, ${0.3 * glowIntensity})`);
+    innerGlow.addColorStop(1, "transparent");
+
+    ctx.save();
+    ctx.clip(nozzlePath);
+    ctx.fillStyle = innerGlow;
+    ctx.fillRect(x - bottomW, bodyBottom, bottomW * 2, nozzleH);
+    ctx.restore();
+  }
+}
+
+function drawPorthole(ctx: CanvasRenderingContext2D, x: number, y: number, radius: number) {
+  // Layer 1: Metal frame ring
+  const frameGrad = ctx.createLinearGradient(x - radius * 1.3, y, x + radius * 1.3, y);
+  frameGrad.addColorStop(0, "#595959");
+  frameGrad.addColorStop(0.5, "#a6a6a6");
+  frameGrad.addColorStop(1, "#595959");
+  ctx.fillStyle = frameGrad;
+  ctx.beginPath();
+  ctx.arc(x, y, radius * 1.2, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Layer 2: Orange glow ring
+  const glowGrad = ctx.createRadialGradient(x, y, radius * 0.6, x, y, radius * 1.05);
+  glowGrad.addColorStop(0, "#f59415");
+  glowGrad.addColorStop(1, "#d07a10");
+  ctx.fillStyle = glowGrad;
+  ctx.beginPath();
+  ctx.arc(x, y, radius * 1.05, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Layer 3: Glass interior with offset highlight
+  const glassGrad = ctx.createRadialGradient(x - radius * 0.2, y - radius * 0.2, radius * 0.1, x, y, radius * 0.85);
+  glassGrad.addColorStop(0, "#d8dce8");
+  glassGrad.addColorStop(0.4, "#8a9ab0");
+  glassGrad.addColorStop(1, "#4a6a8a");
+  ctx.fillStyle = glassGrad;
+  ctx.beginPath();
+  ctx.arc(x, y, radius * 0.85, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Layer 4: Specular glint
+  ctx.save();
+  ctx.globalAlpha = 0.6;
+  ctx.fillStyle = "#ffffff";
+  ctx.beginPath();
+  ctx.arc(x - radius * 0.3, y - radius * 0.3, radius * 0.22, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+}
+
+// ── Vignette ──
+
+export function drawVignette(ctx: CanvasRenderingContext2D, width: number, height: number) {
+  const cx = width / 2;
+  const cy = height / 2;
+  const outerR = Math.sqrt(cx * cx + cy * cy);
+  const vig = ctx.createRadialGradient(cx, cy, outerR * 0.4, cx, cy, outerR);
+  vig.addColorStop(0, "transparent");
+  vig.addColorStop(1, "rgba(0, 0, 0, 0.3)");
+  ctx.fillStyle = vig;
+  ctx.fillRect(0, 0, width, height);
+}
+
+// ── Particle System ──
+
+const EXHAUST_COLORS_PHASE1 = [PRIMARY];
+const EXHAUST_COLORS_PHASE2 = [PRIMARY, "#ff6b35", "#ffcc00"];
+const EXHAUST_COLORS_PHASE3 = [PRIMARY, "#ff6b35", "#ffcc00", "#888888", "#666666"];
+
+export function spawnParticles(
+  particles: Particle[],
+  progress: number,
+  rocketBaseY: number,
+  centerX: number,
+  rocketW: number
+): void {
+  let spawnCount: number;
+  let colors: string[];
+  let sizeRange: [number, number];
+  let lifeRange: [number, number];
+  let velocityScale: number;
+  let spread: number;
+
+  if (progress < 0.3) {
+    spawnCount = Math.random() < 0.5 ? 1 : 2;
+    colors = EXHAUST_COLORS_PHASE1;
+    sizeRange = [1, 3];
+    lifeRange = [15, 30];
+    velocityScale = 1.5;
+    spread = rocketW * 0.5;
+  } else if (progress < 0.6) {
+    spawnCount = 4 + Math.floor(Math.random() * 4);
+    colors = EXHAUST_COLORS_PHASE2;
+    sizeRange = [2, 5];
+    lifeRange = [20, 45];
+    velocityScale = 2.5;
+    spread = rocketW * 0.8;
+  } else {
+    spawnCount = 10 + Math.floor(Math.random() * 8);
+    colors = EXHAUST_COLORS_PHASE3;
+    sizeRange = [3, 8];
+    lifeRange = [30, 60];
+    velocityScale = 4;
+    spread = rocketW * 1.5;
+  }
+
+  for (let i = 0; i < spawnCount; i++) {
+    const dead = particles.find(p => p.life <= 0);
+    if (!dead) break;
+
+    const life = lifeRange[0] + Math.random() * (lifeRange[1] - lifeRange[0]);
+    dead.x = centerX + (Math.random() - 0.5) * spread;
+    dead.y = rocketBaseY;
+    dead.vx = (Math.random() - 0.5) * velocityScale;
+    dead.vy = 1 + Math.random() * velocityScale;
+    dead.life = life;
+    dead.maxLife = life;
+    dead.size = sizeRange[0] + Math.random() * (sizeRange[1] - sizeRange[0]);
+    dead.color = colors[Math.floor(Math.random() * colors.length)];
+  }
+}
+
+export function updateParticles(particles: Particle[]): void {
+  for (const p of particles) {
+    if (p.life <= 0) continue;
+    p.x += p.vx;
+    p.y += p.vy;
+    p.vy += 0.1;
+    p.vx *= 0.98;
+    p.life -= 1;
+  }
+}
+
+export function drawExhaust(ctx: CanvasRenderingContext2D, particles: Particle[], width: number) {
+  const isMobile = width < 768;
+
+  for (const p of particles) {
+    if (p.life <= 0) continue;
+    const alpha = p.life / p.maxLife;
+    ctx.globalAlpha = alpha;
+    ctx.fillStyle = p.color;
+
+    if (!isMobile) {
+      ctx.shadowBlur = 6;
+      ctx.shadowColor = p.color;
+    }
+
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  ctx.shadowBlur = 0;
+  ctx.shadowColor = "transparent";
+  ctx.globalAlpha = 1;
+}
+
+export function createParticlePool(width: number): Particle[] {
+  const count = width < 768 ? 100 : 200;
+  return Array.from({ length: count }, () => ({
+    x: 0,
+    y: 0,
+    vx: 0,
+    vy: 0,
+    life: 0,
+    maxLife: 0,
+    size: 0,
+    color: PRIMARY
+  }));
+}

--- a/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
+++ b/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
@@ -424,7 +424,7 @@ export function getRocketY(progress: number, height: number): number {
   const dims = getRocketDimensions(0, height);
   const padHeight = 8;
   // Rocket sits at the bottom of the scene, just above ground level
-  const launchPadY = height - height * 0.05 - padHeight;
+  const launchPadY = height - height * 0.05 - padHeight - 130;
   const onPadY = launchPadY - dims.rocketH;
 
   if (progress <= LAUNCH_START) return onPadY;
@@ -578,7 +578,7 @@ export function drawRocket(
 
   // ── 9. Launch pad ──
   if (progress < 0.8) {
-    const padY = height - height * 0.05;
+    const padY = height - height * 0.05 - 100;
     const padW = rocketW * 2.5;
     const padGrad = ctx.createLinearGradient(centerX - padW / 2, padY, centerX + padW / 2, padY);
     padGrad.addColorStop(0, "#3a3a4a");
@@ -801,9 +801,10 @@ function drawPorthole(ctx: CanvasRenderingContext2D, x: number, y: number, radiu
 }
 
 // ── Launch Smoke (tweak these to adjust smoke timing/size) ──
-export const SMOKE_IGNITION_INTENSITY = 0.6; // max intensity during ignition phase (0-1)
+export const SMOKE_IDLE_INTENSITY = 0.8; // baseline smoke visible even at idle (0-1)
+export const SMOKE_IGNITION_INTENSITY = 0.9; // max intensity during ignition phase (0-1)
 export const SMOKE_LAUNCH_FILL_SPEED = 0.4; // fraction of launch phase to reach full (lower = faster)
-export const SMOKE_CLOUD_SIZE = 0.08; // base cloud radius as fraction of width
+export const SMOKE_CLOUD_SIZE = 0.09; // base cloud radius as fraction of width
 export const SMOKE_DRIFT_SPEED = 0.0001; // how fast clouds billow/drift
 export const SMOKE_GROUND_Y = 0.05; // ground level as fraction from bottom
 
@@ -911,13 +912,14 @@ function drawSmokeLayer(
   height: number,
   time: number
 ) {
-  // Smoke only appears during ignition and grows massively during launch
-  if (progress < IGNITION_START) return;
-
   let smokeIntensity: number;
-  if (progress < LAUNCH_START) {
-    // Ignition phase: smoke builds quickly
-    smokeIntensity = ((progress - IGNITION_START) / IGNITION_RANGE) * SMOKE_IGNITION_INTENSITY;
+  if (progress < IGNITION_START) {
+    // Idle: baseline smoke always visible
+    smokeIntensity = SMOKE_IDLE_INTENSITY;
+  } else if (progress < LAUNCH_START) {
+    // Ignition phase: smoke builds from idle to ignition intensity
+    const t = (progress - IGNITION_START) / IGNITION_RANGE;
+    smokeIntensity = SMOKE_IDLE_INTENSITY + t * (SMOKE_IGNITION_INTENSITY - SMOKE_IDLE_INTENSITY);
   } else {
     // Launch phase: smoke hits full fast (easeOut curve)
     const launchT = Math.min(1, (progress - LAUNCH_START) / (LAUNCH_RANGE * SMOKE_LAUNCH_FILL_SPEED));

--- a/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
+++ b/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
@@ -1,3 +1,12 @@
+// ── Scroll Phase Thresholds (tweak these to adjust timing) ──
+// Idle: 0 → IGNITION_START (sputtering engine, minimal particles)
+// Ignition: IGNITION_START → LAUNCH_START (vibration, nozzle glow, moderate exhaust)
+// Launch: LAUNCH_START → 1.0 (liftoff, star streaks, full exhaust)
+export const IGNITION_START = 0.02;
+export const LAUNCH_START = 0.1;
+const LAUNCH_RANGE = 1 - LAUNCH_START; // duration of launch phase
+const IGNITION_RANGE = LAUNCH_START - IGNITION_START; // duration of ignition phase
+
 // ── Data Structures ──
 
 export interface Star {
@@ -224,8 +233,8 @@ export function drawStarfield(
     ctx.fill();
 
     // Phase 3: star streaks (desktop only)
-    if (!isMobile && progress > 0.6) {
-      const streakLength = ((progress - 0.6) / 0.4) * 15;
+    if (!isMobile && progress > LAUNCH_START) {
+      const streakLength = ((progress - LAUNCH_START) / LAUNCH_RANGE) * 15;
       ctx.strokeStyle = `rgba(255, 255, 255, ${twinkle * 0.4})`;
       ctx.lineWidth = star.radius * 0.5;
       ctx.beginPath();
@@ -377,8 +386,8 @@ export function drawSkyline(
   ctx.fillRect(0, height - 30, width, 30);
 
   // Exhaust glow on buildings (Phase 3)
-  if (progress > 0.6) {
-    const glowIntensity = (progress - 0.6) / 0.4;
+  if (progress > LAUNCH_START) {
+    const glowIntensity = (progress - LAUNCH_START) / LAUNCH_RANGE;
     const rocketBaseX = width / 2;
     const maxBH = buildings.reduce((max, b) => Math.max(max, b.height), 0);
     const rocketBaseY = baseY - maxBH * 0.5;
@@ -418,10 +427,10 @@ export function getRocketY(progress: number, height: number): number {
   const launchPadY = height - height * 0.05 - padHeight;
   const onPadY = launchPadY - dims.rocketH;
 
-  if (progress <= 0.6) return onPadY;
+  if (progress <= LAUNCH_START) return onPadY;
 
   // Phase 3: liftoff with easeIn
-  const t = (progress - 0.6) / 0.4;
+  const t = (progress - LAUNCH_START) / LAUNCH_RANGE;
   const eased = t * t;
   const targetY = -dims.rocketH - 40;
   return onPadY + (targetY - onPadY) * eased;
@@ -447,8 +456,8 @@ export function drawRocket(
 
   // Phase 2 vibration
   let offsetX = 0;
-  if (progress > 0.3 && progress <= 0.6) {
-    const intensity = (progress - 0.3) / 0.3;
+  if (progress > IGNITION_START && progress <= LAUNCH_START) {
+    const intensity = (progress - IGNITION_START) / IGNITION_RANGE;
     offsetX = (Math.random() * 2 - 1) * intensity * 2;
   }
 
@@ -728,8 +737,8 @@ function drawNozzle(
   ctx.fill(nozzlePath);
 
   // Inner glow during ignition/launch
-  if (progress > 0.15) {
-    const glowIntensity = Math.min(1, (progress - 0.15) / 0.3);
+  if (progress > IGNITION_START) {
+    const glowIntensity = Math.min(1, (progress - IGNITION_START) / IGNITION_RANGE);
     const innerGlow = ctx.createRadialGradient(
       x,
       bodyBottom + nozzleH * 0.8,
@@ -824,14 +833,14 @@ export function spawnParticles(
   let velocityScale: number;
   let spread: number;
 
-  if (progress < 0.3) {
+  if (progress < IGNITION_START) {
     spawnCount = Math.random() < 0.5 ? 1 : 2;
     colors = EXHAUST_COLORS_PHASE1;
     sizeRange = [1, 3];
     lifeRange = [15, 30];
     velocityScale = 1.5;
     spread = rocketW * 0.5;
-  } else if (progress < 0.6) {
+  } else if (progress < LAUNCH_START) {
     spawnCount = 4 + Math.floor(Math.random() * 4);
     colors = EXHAUST_COLORS_PHASE2;
     sizeRange = [2, 5];

--- a/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
+++ b/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
@@ -59,7 +59,7 @@ export interface Particle {
 
 // ── Constants ──
 
-const SKY_COLOR = "#0a0a1a";
+const SKY_COLOR = "#202124";
 const PRIMARY = "#f59415";
 
 // Window colors: subtle warm tones for lit, cool grays for dark (matching SVG)
@@ -206,11 +206,11 @@ export function generateWindowStates(buildings: Building[], onRatio: number): bo
 // ── Drawing Functions ──
 
 export function drawSky(ctx: CanvasRenderingContext2D, width: number, height: number) {
-  // Sky gradient: deep blue-black at top, slightly lighter at horizon
+  // Sky gradient: dark at top, slightly lighter at horizon
   const grad = ctx.createLinearGradient(0, 0, 0, height);
-  grad.addColorStop(0, "#050510");
+  grad.addColorStop(0, "#151517");
   grad.addColorStop(0.7, SKY_COLOR);
-  grad.addColorStop(1, "#0f0f2a");
+  grad.addColorStop(1, "#1a1a1d");
   ctx.fillStyle = grad;
   ctx.fillRect(0, 0, width, height);
 }

--- a/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
+++ b/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
@@ -800,6 +800,172 @@ function drawPorthole(ctx: CanvasRenderingContext2D, x: number, y: number, radiu
   ctx.restore();
 }
 
+// ── Launch Smoke (tweak these to adjust smoke timing/size) ──
+export const SMOKE_IGNITION_INTENSITY = 0.6; // max intensity during ignition phase (0-1)
+export const SMOKE_LAUNCH_FILL_SPEED = 0.4; // fraction of launch phase to reach full (lower = faster)
+export const SMOKE_CLOUD_SIZE = 0.08; // base cloud radius as fraction of width
+export const SMOKE_DRIFT_SPEED = 0.0001; // how fast clouds billow/drift
+export const SMOKE_GROUND_Y = 0.05; // ground level as fraction from bottom
+
+const SMOKE_COLORS_BACK = [
+  "rgba(139, 100, 50, 0.7)", // dark golden brown
+  "rgba(120, 85, 40, 0.65)",
+  "rgba(150, 110, 55, 0.6)",
+  "rgba(100, 75, 35, 0.55)"
+];
+
+const SMOKE_COLORS_FRONT = [
+  "rgba(245, 180, 80, 0.75)", // warm orange
+  "rgba(250, 195, 100, 0.7)",
+  "rgba(240, 170, 65, 0.65)",
+  "rgba(255, 200, 110, 0.6)"
+];
+
+interface SmokeCloud {
+  // Relative position: cx is fraction of width from center, cy is fraction from bottom
+  cx: number;
+  cy: number;
+  // Size multiplier
+  scale: number;
+  // Shape variation seed
+  seed: number;
+}
+
+// Pre-generate cloud positions for consistency across frames
+// Back layer: wider spread, positioned behind building area
+const BACK_CLOUDS: SmokeCloud[] = [
+  { cx: -0.18, cy: 0.12, scale: 1.3, seed: 0.2 },
+  { cx: -0.08, cy: 0.08, scale: 1.1, seed: 0.7 },
+  { cx: 0.0, cy: 0.05, scale: 1.4, seed: 0.4 },
+  { cx: 0.09, cy: 0.09, scale: 1.2, seed: 0.9 },
+  { cx: 0.19, cy: 0.11, scale: 1.3, seed: 0.1 },
+  { cx: -0.25, cy: 0.15, scale: 1.0, seed: 0.5 },
+  { cx: 0.26, cy: 0.14, scale: 1.1, seed: 0.3 },
+  { cx: -0.32, cy: 0.18, scale: 0.9, seed: 0.8 },
+  { cx: 0.33, cy: 0.17, scale: 0.9, seed: 0.6 }
+];
+
+// Front layer: concentrated near center, overlaps buildings
+const FRONT_CLOUDS: SmokeCloud[] = [
+  { cx: -0.12, cy: 0.04, scale: 1.5, seed: 0.3 },
+  { cx: 0.0, cy: 0.0, scale: 1.8, seed: 0.8 },
+  { cx: 0.13, cy: 0.03, scale: 1.5, seed: 0.6 },
+  { cx: -0.22, cy: 0.08, scale: 1.3, seed: 0.1 },
+  { cx: 0.23, cy: 0.07, scale: 1.3, seed: 0.9 },
+  { cx: -0.05, cy: 0.1, scale: 1.6, seed: 0.5 },
+  { cx: 0.06, cy: 0.09, scale: 1.6, seed: 0.2 },
+  { cx: -0.3, cy: 0.12, scale: 1.1, seed: 0.7 },
+  { cx: 0.31, cy: 0.11, scale: 1.1, seed: 0.4 },
+  { cx: -0.38, cy: 0.15, scale: 1.0, seed: 0.35 },
+  { cx: 0.39, cy: 0.14, scale: 1.0, seed: 0.65 },
+  { cx: 0.0, cy: 0.16, scale: 1.4, seed: 0.15 }
+];
+
+function drawPuffyCloud(ctx: CanvasRenderingContext2D, cx: number, cy: number, radius: number, seed: number) {
+  // Draw a cloud shape using overlapping circles and bezier curves
+  const puffs = 5 + Math.floor(seed * 4); // 5-8 puffs per cloud
+  ctx.beginPath();
+
+  for (let i = 0; i < puffs; i++) {
+    const angle = (i / puffs) * Math.PI * 2 + seed * Math.PI;
+    const dist = radius * (0.3 + seed * 0.3 + Math.sin(angle * 2 + seed * 5) * 0.15);
+    const px = cx + Math.cos(angle) * dist;
+    const py = cy + Math.sin(angle) * dist * 0.6; // squash vertically
+    const puffR = radius * (0.5 + Math.sin(i * 2.3 + seed * 7) * 0.2);
+    ctx.moveTo(px + puffR, py);
+    ctx.arc(px, py, puffR, 0, Math.PI * 2);
+  }
+
+  // Central fill puff
+  ctx.moveTo(cx + radius * 0.6, cy);
+  ctx.arc(cx, cy, radius * 0.6, 0, Math.PI * 2);
+
+  ctx.fill();
+}
+
+function drawSmokeLayer(
+  ctx: CanvasRenderingContext2D,
+  clouds: SmokeCloud[],
+  colors: string[],
+  progress: number,
+  width: number,
+  height: number,
+  time: number
+) {
+  // Smoke only appears during ignition and grows massively during launch
+  if (progress < IGNITION_START) return;
+
+  let smokeIntensity: number;
+  if (progress < LAUNCH_START) {
+    // Ignition phase: smoke builds quickly
+    smokeIntensity = ((progress - IGNITION_START) / IGNITION_RANGE) * SMOKE_IGNITION_INTENSITY;
+  } else {
+    // Launch phase: smoke hits full fast (easeOut curve)
+    const launchT = Math.min(1, (progress - LAUNCH_START) / (LAUNCH_RANGE * SMOKE_LAUNCH_FILL_SPEED));
+    smokeIntensity = SMOKE_IGNITION_INTENSITY + (1 - (1 - launchT) * (1 - launchT)) * (1 - SMOKE_IGNITION_INTENSITY);
+  }
+
+  const baseRadius = width * SMOKE_CLOUD_SIZE;
+  const centerX = width / 2;
+  const baseY = height - height * SMOKE_GROUND_Y;
+
+  ctx.save();
+
+  for (let i = 0; i < clouds.length; i++) {
+    const cloud = clouds[i];
+
+    // Only show clouds progressively — outer clouds appear later
+    const cloudDist = Math.abs(cloud.cx);
+    const appearThreshold = cloudDist * 0.8;
+    if (smokeIntensity < appearThreshold) continue;
+
+    const localIntensity = Math.min(1, (smokeIntensity - appearThreshold) / (1 - appearThreshold));
+
+    // Animated drift: clouds slowly billow outward and upward
+    const drift = time * SMOKE_DRIFT_SPEED * (0.5 + cloud.seed * 0.5);
+    const driftX = Math.sin(drift + cloud.seed * 10) * width * 0.01;
+    const driftY = Math.cos(drift * 0.7 + cloud.seed * 5) * height * 0.005;
+
+    const cx = centerX + cloud.cx * width * smokeIntensity + driftX;
+    const cy = baseY - cloud.cy * height * smokeIntensity + driftY;
+    const radius = baseRadius * cloud.scale * localIntensity * smokeIntensity;
+
+    if (radius < 2) continue;
+
+    // Pick color and apply gradient for depth
+    const color = colors[i % colors.length];
+    const grad = ctx.createRadialGradient(cx, cy - radius * 0.2, 0, cx, cy, radius * 1.2);
+    grad.addColorStop(0, color);
+    grad.addColorStop(1, color.replace(/[\d.]+\)$/, "0)"));
+
+    ctx.fillStyle = grad;
+    ctx.globalAlpha = localIntensity;
+    drawPuffyCloud(ctx, cx, cy, radius, cloud.seed);
+  }
+
+  ctx.restore();
+}
+
+export function drawSmokeBack(
+  ctx: CanvasRenderingContext2D,
+  progress: number,
+  width: number,
+  height: number,
+  time: number
+) {
+  drawSmokeLayer(ctx, BACK_CLOUDS, SMOKE_COLORS_BACK, progress, width, height, time);
+}
+
+export function drawSmokeFront(
+  ctx: CanvasRenderingContext2D,
+  progress: number,
+  width: number,
+  height: number,
+  time: number
+) {
+  drawSmokeLayer(ctx, FRONT_CLOUDS, SMOKE_COLORS_FRONT, progress, width, height, time);
+}
+
 // ── Vignette ──
 
 export function drawVignette(ctx: CanvasRenderingContext2D, width: number, height: number) {

--- a/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
+++ b/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
@@ -12,11 +12,29 @@ export interface Building {
   x: number;
   width: number;
   height: number;
-  windowCols: number;
-  windowRows: number;
-  topStyle: "flat" | "dome" | "peak" | "stepped";
-  layer: number; // 0=back, 1=mid, 2=front
-  windowColorIndices: number[]; // pre-assigned color index per window
+  color: string;
+  layer: number; // 0=back, 1=front
+  roofStyle: "flat" | "peaked" | "stepped" | "tower";
+  // Tower extension on top (only for "tower" roofStyle)
+  towerWidth: number; // fraction of building width (0.15-0.3)
+  towerHeight: number; // extra height above main building
+  // Window groups: 3-column staggered blocks
+  windowGroups: WindowGroup[];
+}
+
+export interface WindowGroup {
+  // Position relative to building left/top
+  relX: number;
+  relY: number;
+  cols: number;
+  rows: number;
+  winW: number;
+  winH: number;
+  gapX: number;
+  gapY: number;
+  // Per-window: color index + stagger offset
+  colorIndices: number[];
+  staggerOffsets: number[]; // Y offset per column for organic feel
 }
 
 export interface Particle {
@@ -35,17 +53,16 @@ export interface Particle {
 const SKY_COLOR = "#0a0a1a";
 const PRIMARY = "#f59415";
 
-const WINDOW_COLORS_ON = ["#ffd870", "#ffe8a0", "#ffcc44", "#e8c060", "#f0d080", "#ffffff"];
+// Window colors: subtle warm tones for lit, cool grays for dark (matching SVG)
+const WINDOW_COLORS_ON = ["#e8d8b0", "#ddd0a8", "#d4c898", "#cfc090", "#e0d4b0"];
 
-const WINDOW_COLORS_OFF = ["#7b7a7c", "#9da3ab", "#b3b9c2", "#bcc1cc", "#c5cad4", "#505060", "#3a3a4a", "#606878"];
+const WINDOW_COLORS_OFF = ["#9da3ab", "#b3b9c2", "#b7bbc4", "#bcc1cc", "#c5cad4"];
 
-const BUILDING_GRADIENTS: [string, string][] = [
-  ["#1a1a2e", "#12121f"], // back layer
-  ["#252540", "#1a1a30"], // mid layer
-  ["#2d2d4a", "#1e1e35"] // front layer
-];
+// Building body colors: cool gray-blues, lighter = further back
+const BUILDING_COLORS_BACK = ["#e3e9f5", "#e4e9f5", "#dde2ed", "#dce2ed"];
+const BUILDING_COLORS_FRONT = ["#d7dde8", "#ccd1db", "#c5cad4"];
 
-const TOP_STYLES: Building["topStyle"][] = ["flat", "dome", "peak", "stepped"];
+const ROOF_STYLES: Building["roofStyle"][] = ["flat", "peaked", "stepped", "tower"];
 
 // ── Generation Functions ──
 
@@ -65,47 +82,114 @@ export function generateStars(width: number, height: number): Star[] {
   return stars;
 }
 
-export function generateBuildings(width: number, height: number): Building[] {
-  const isMobile = width < 768;
-  const count = isMobile ? 5 + Math.floor(Math.random() * 3) : 8 + Math.floor(Math.random() * 6);
-  const buildings: Building[] = [];
-  const avgWidth = width / (count * 0.7);
+function createWindowGroup(buildingW: number, buildingH: number, relX: number, sectionW: number): WindowGroup {
+  const winW = Math.max(5, sectionW * 0.08);
+  const winH = winW * 1.4;
+  const gapX = winW * 3;
+  const gapY = winH * 2.5;
+  const cols = Math.max(2, Math.min(3, Math.floor(sectionW / (winW + gapX))));
+  const availH = buildingH * 0.6;
+  const rows = Math.max(2, Math.min(7, Math.floor(availH / (winH + gapY))));
 
-  for (let i = 0; i < count; i++) {
-    const bWidth = avgWidth * (0.6 + Math.random() * 0.8);
-    const bHeight = height * (0.25 + Math.random() * 0.35);
-    const x = (i / count) * width - bWidth * 0.1 + Math.random() * (avgWidth * 0.3);
-    const windowCols = Math.max(3, Math.floor(bWidth / 10));
-    const windowRows = Math.max(4, Math.floor(bHeight / 12));
-    const total = windowCols * windowRows;
+  const total = cols * rows;
+  const colorIndices = Array.from({ length: total }, () => Math.floor(Math.random() * WINDOW_COLORS_OFF.length));
+  // Stagger: each column has a slight random Y offset
+  const staggerOffsets = Array.from({ length: cols }, () => Math.random() * gapY * 0.4);
 
-    // Pre-assign a color index to each window for consistency across frames
-    const windowColorIndices = Array.from({ length: total }, () =>
-      Math.floor(Math.random() * WINDOW_COLORS_OFF.length)
-    );
+  return {
+    relX,
+    relY: buildingH * 0.08,
+    cols,
+    rows,
+    winW,
+    winH,
+    gapX,
+    gapY,
+    colorIndices,
+    staggerOffsets
+  };
+}
 
-    const layer = i < count / 3 ? 0 : i < (count * 2) / 3 ? 1 : 2;
+function createBuilding(
+  x: number,
+  bWidth: number,
+  bHeight: number,
+  layer: number,
+  roofStyle: Building["roofStyle"]
+): Building {
+  const colors = layer === 0 ? BUILDING_COLORS_BACK : BUILDING_COLORS_FRONT;
+  const color = colors[Math.floor(Math.random() * colors.length)];
 
-    buildings.push({
-      x,
-      width: bWidth,
-      height: bHeight,
-      windowCols,
-      windowRows,
-      topStyle: TOP_STYLES[Math.floor(Math.random() * TOP_STYLES.length)],
-      layer,
-      windowColorIndices
-    });
+  const towerWidth = roofStyle === "tower" ? 0.15 + Math.random() * 0.15 : 0;
+  const towerHeight = roofStyle === "tower" ? bHeight * (0.15 + Math.random() * 0.15) : 0;
+
+  // Single centered window group per building (like SVG's 3-col staggered blocks)
+  const windowGroups: WindowGroup[] = [];
+  const innerPad = bWidth * 0.15;
+  const usableW = bWidth - innerPad * 2;
+
+  if (usableW > 30) {
+    windowGroups.push(createWindowGroup(bWidth, bHeight, innerPad, usableW));
   }
 
-  // Sort by layer so back buildings draw first
+  return {
+    x,
+    width: bWidth,
+    height: bHeight,
+    color,
+    layer,
+    roofStyle,
+    towerWidth,
+    towerHeight,
+    windowGroups
+  };
+}
+
+export function generateBuildings(width: number, height: number): Building[] {
+  const isMobile = width < 768;
+  const buildings: Building[] = [];
+
+  // Center gap: rocket occupies the middle ~40%
+  const centerGapLeft = width * 0.3;
+  const centerGapRight = width * 0.7;
+
+  // Left side buildings: 3-4 buildings, varying heights
+  const leftCount = isMobile ? 2 : 3 + Math.floor(Math.random() * 2);
+  const leftZone = centerGapLeft;
+  for (let i = 0; i < leftCount; i++) {
+    const layer = i < Math.ceil(leftCount / 2) ? 0 : 1;
+    const bWidth = (leftZone / leftCount) * (0.8 + Math.random() * 0.5);
+    const bHeight = height * (0.4 + Math.random() * 0.25);
+    // Spread buildings across the left zone, clamp to stay within zone
+    const maxX = centerGapLeft - bWidth;
+    const x = Math.min(maxX, (i / leftCount) * leftZone);
+    const roofStyle = ROOF_STYLES[Math.floor(Math.random() * ROOF_STYLES.length)];
+    buildings.push(createBuilding(Math.max(0, x), bWidth, bHeight, layer, roofStyle));
+  }
+
+  // Right side buildings: 3-4 buildings, varying heights
+  const rightCount = isMobile ? 2 : 3 + Math.floor(Math.random() * 2);
+  const rightZone = width - centerGapRight;
+  for (let i = 0; i < rightCount; i++) {
+    const layer = i < Math.ceil(rightCount / 2) ? 0 : 1;
+    const bWidth = (rightZone / rightCount) * (0.8 + Math.random() * 0.5);
+    const bHeight = height * (0.4 + Math.random() * 0.25);
+    const x = centerGapRight + (i / rightCount) * rightZone;
+    const roofStyle = ROOF_STYLES[Math.floor(Math.random() * ROOF_STYLES.length)];
+    buildings.push(createBuilding(x, bWidth, bHeight, layer, roofStyle));
+  }
+
+  // Sort: back layer first, then front
   buildings.sort((a, b) => a.layer - b.layer);
   return buildings;
 }
 
 export function generateWindowStates(buildings: Building[], onRatio: number): boolean[][] {
   return buildings.map(b => {
-    const total = b.windowCols * b.windowRows;
+    let total = 0;
+    for (const g of b.windowGroups) {
+      total += g.cols * g.rows;
+    }
     return Array.from({ length: total }, () => Math.random() < onRatio);
   });
 }
@@ -155,57 +239,105 @@ export function drawStarfield(
 
 // ── Building Drawing ──
 
-function drawBuildingShape(ctx: CanvasRenderingContext2D, b: Building, topY: number, baseY: number) {
+function drawBuildingBody(ctx: CanvasRenderingContext2D, b: Building, topY: number, baseY: number) {
+  const cx = b.x + b.width / 2;
+
+  // Main body rectangle
   ctx.beginPath();
+  ctx.rect(b.x, topY, b.width, baseY - topY);
+  ctx.fill();
 
-  switch (b.topStyle) {
-    case "dome":
-      ctx.moveTo(b.x, baseY);
-      ctx.lineTo(b.x, topY + b.width * 0.15);
-      ctx.quadraticCurveTo(b.x, topY, b.x + b.width * 0.15, topY);
-      ctx.lineTo(b.x + b.width * 0.85, topY);
-      ctx.quadraticCurveTo(b.x + b.width, topY, b.x + b.width, topY + b.width * 0.15);
-      ctx.lineTo(b.x + b.width, baseY);
+  // Roofline features
+  switch (b.roofStyle) {
+    case "peaked": {
+      // Triangular peaked roof
+      const peakH = b.height * 0.08;
+      const capW = b.width * 0.7;
+      const capX = cx - capW / 2;
+      ctx.beginPath();
+      ctx.moveTo(capX, topY);
+      ctx.lineTo(cx, topY - peakH);
+      ctx.lineTo(capX + capW, topY);
       ctx.closePath();
-      break;
-
-    case "peak": {
-      const peakH = b.height * 0.12;
-      ctx.moveTo(b.x, baseY);
-      ctx.lineTo(b.x, topY + peakH);
-      ctx.lineTo(b.x + b.width * 0.35, topY + peakH);
-      ctx.quadraticCurveTo(b.x + b.width * 0.5, topY - peakH * 0.3, b.x + b.width * 0.65, topY + peakH);
-      ctx.lineTo(b.x + b.width, topY + peakH);
-      ctx.lineTo(b.x + b.width, baseY);
-      ctx.closePath();
+      ctx.fill();
+      // Roofline cap bar
+      ctx.fillRect(b.x + b.width * 0.1, topY - 2, b.width * 0.8, 4);
       break;
     }
 
     case "stepped": {
-      const stepW = b.width * 0.2;
-      const stepH = b.height * 0.1;
-      ctx.moveTo(b.x, baseY);
-      ctx.lineTo(b.x, topY + stepH);
-      ctx.lineTo(b.x + stepW, topY + stepH);
-      ctx.lineTo(b.x + stepW, topY);
-      ctx.lineTo(b.x + b.width - stepW, topY);
-      ctx.lineTo(b.x + b.width - stepW, topY + stepH);
-      ctx.lineTo(b.x + b.width, topY + stepH);
-      ctx.lineTo(b.x + b.width, baseY);
-      ctx.closePath();
+      // Stepped setback: narrower section on top
+      const stepW = b.width * 0.6;
+      const stepH = b.height * 0.12;
+      const stepX = cx - stepW / 2;
+      ctx.beginPath();
+      ctx.rect(stepX, topY - stepH, stepW, stepH);
+      ctx.fill();
+      // Even narrower top piece
+      const topW = b.width * 0.35;
+      const topH = b.height * 0.06;
+      ctx.beginPath();
+      ctx.rect(cx - topW / 2, topY - stepH - topH, topW, topH);
+      ctx.fill();
+      break;
+    }
+
+    case "tower": {
+      // Narrow tower extending above main building
+      const twrW = b.width * b.towerWidth;
+      const twrX = cx - twrW / 2;
+      ctx.beginPath();
+      ctx.rect(twrX, topY - b.towerHeight, twrW, b.towerHeight);
+      ctx.fill();
+      // Small spire/cap on top of tower
+      const capW = twrW * 0.6;
+      const capH = b.towerHeight * 0.25;
+      ctx.beginPath();
+      ctx.rect(cx - capW / 2, topY - b.towerHeight - capH, capW, capH);
+      ctx.fill();
+      // Antenna spire
+      ctx.strokeStyle = b.color;
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.moveTo(cx, topY - b.towerHeight - capH);
+      ctx.lineTo(cx, topY - b.towerHeight - capH - b.towerHeight * 0.3);
+      ctx.stroke();
       break;
     }
 
     default:
-      // flat with subtle rounded top corners
-      ctx.moveTo(b.x, baseY);
-      ctx.lineTo(b.x, topY + 3);
-      ctx.quadraticCurveTo(b.x, topY, b.x + 3, topY);
-      ctx.lineTo(b.x + b.width - 3, topY);
-      ctx.quadraticCurveTo(b.x + b.width, topY, b.x + b.width, topY + 3);
-      ctx.lineTo(b.x + b.width, baseY);
-      ctx.closePath();
+      // Flat: just a subtle horizontal roofline accent
+      ctx.fillRect(b.x + b.width * 0.05, topY - 2, b.width * 0.9, 3);
       break;
+  }
+}
+
+function drawBuildingWindows(ctx: CanvasRenderingContext2D, b: Building, topY: number, states: boolean[]) {
+  let stateIdx = 0;
+
+  for (const g of b.windowGroups) {
+    for (let row = 0; row < g.rows; row++) {
+      for (let col = 0; col < g.cols; col++) {
+        const idx = stateIdx + row * g.cols + col;
+        const stagger = g.staggerOffsets[col] ?? 0;
+        const wx = b.x + g.relX + col * (g.winW + g.gapX);
+        const wy = topY + g.relY + row * (g.winH + g.gapY) + stagger;
+        const isOn = states[idx];
+        const colorIdx = g.colorIndices[row * g.cols + col] ?? 0;
+
+        if (isOn) {
+          const onIdx = colorIdx % WINDOW_COLORS_ON.length;
+          ctx.fillStyle = WINDOW_COLORS_ON[onIdx];
+        } else {
+          ctx.fillStyle = WINDOW_COLORS_OFF[colorIdx % WINDOW_COLORS_OFF.length];
+        }
+
+        ctx.fillRect(wx, wy, g.winW, g.winH);
+      }
+    }
+    stateIdx += g.cols * g.rows;
+    ctx.shadowBlur = 0;
+    ctx.shadowColor = "transparent";
   }
 }
 
@@ -219,70 +351,21 @@ export function drawSkyline(
   height: number
 ) {
   const baseY = height;
-  const isMobile = width < 768;
 
   for (let i = 0; i < buildings.length; i++) {
     const b = buildings[i];
     const topY = baseY - b.height;
 
-    // Building body with gradient
-    const colors = BUILDING_GRADIENTS[Math.min(b.layer, 2)];
-    const grad = ctx.createLinearGradient(b.x, topY, b.x, baseY);
-    grad.addColorStop(0, colors[0]);
-    grad.addColorStop(1, colors[1]);
-
-    ctx.globalAlpha = b.layer === 0 ? 0.5 : b.layer === 1 ? 0.65 : 0.8;
-
-    drawBuildingShape(ctx, b, topY, baseY);
-    ctx.fillStyle = grad;
-    ctx.fill();
-
-    // Subtle edge highlight on front buildings
-    if (b.layer === 2) {
-      drawBuildingShape(ctx, b, topY, baseY);
-      ctx.strokeStyle = "rgba(100, 100, 140, 0.3)";
-      ctx.lineWidth = 1;
-      ctx.stroke();
-    }
-
+    // Building body: solid color, full opacity (depth via color difference)
+    ctx.globalAlpha = b.layer === 0 ? 0.85 : 1;
+    ctx.fillStyle = b.color;
+    drawBuildingBody(ctx, b, topY, baseY);
     ctx.globalAlpha = 1;
 
     // Windows
     const states = windowStates[i];
-    if (!states) continue;
-
-    const winW = Math.max(5, (b.width / (b.windowCols + 1)) * 0.5);
-    const winH = Math.max(5, (b.height / (b.windowRows + 1)) * 0.4);
-    const padX = (b.width - b.windowCols * winW) / (b.windowCols + 1);
-    const padY = (b.height - b.windowRows * winH) / (b.windowRows + 1);
-
-    for (let row = 0; row < b.windowRows; row++) {
-      for (let col = 0; col < b.windowCols; col++) {
-        const idx = row * b.windowCols + col;
-        const wx = b.x + padX + col * (winW + padX);
-        const wy = topY + padY + row * (winH + padY);
-        const isOn = states[idx];
-        const colorIdx = b.windowColorIndices[idx] ?? 0;
-
-        if (isOn) {
-          const onColorIdx = colorIdx % WINDOW_COLORS_ON.length;
-          ctx.fillStyle = WINDOW_COLORS_ON[onColorIdx];
-
-          // Glow on lit windows (desktop only)
-          if (!isMobile) {
-            ctx.shadowColor = WINDOW_COLORS_ON[onColorIdx];
-            ctx.shadowBlur = 3;
-          }
-        } else {
-          ctx.fillStyle = WINDOW_COLORS_OFF[colorIdx];
-          ctx.shadowBlur = 0;
-        }
-
-        ctx.fillRect(wx, wy, winW, winH);
-      }
-      // Reset shadow after each row for performance
-      ctx.shadowBlur = 0;
-      ctx.shadowColor = "transparent";
+    if (states) {
+      drawBuildingWindows(ctx, b, topY, states);
     }
   }
 
@@ -328,11 +411,11 @@ export function getRocketDimensions(width: number, height: number) {
   return { rocketH, rocketW, centerX, noseH, bodyH, nozzleH, finH };
 }
 
-export function getRocketY(progress: number, height: number, buildings: Building[]): number {
-  const maxBuildingH = buildings.reduce((max, b) => Math.max(max, b.height), 0);
+export function getRocketY(progress: number, height: number): number {
   const dims = getRocketDimensions(0, height);
   const padHeight = 8;
-  const launchPadY = height - maxBuildingH * 0.4 - padHeight;
+  // Rocket sits at the bottom of the scene, just above ground level
+  const launchPadY = height - height * 0.05 - padHeight;
   const onPadY = launchPadY - dims.rocketH;
 
   if (progress <= 0.6) return onPadY;
@@ -356,12 +439,11 @@ export function drawRocket(
   progress: number,
   _time: number,
   width: number,
-  height: number,
-  buildings: Building[]
+  height: number
 ) {
   const dims = getRocketDimensions(width, height);
   const { rocketH, rocketW, centerX, noseH, bodyH, nozzleH, finH } = dims;
-  const rocketY = getRocketY(progress, height, buildings);
+  const rocketY = getRocketY(progress, height);
 
   // Phase 2 vibration
   let offsetX = 0;
@@ -487,8 +569,7 @@ export function drawRocket(
 
   // ── 9. Launch pad ──
   if (progress < 0.8) {
-    const maxBuildingH = buildings.reduce((max, b) => Math.max(max, b.height), 0);
-    const padY = height - maxBuildingH * 0.4;
+    const padY = height - height * 0.05;
     const padW = rocketW * 2.5;
     const padGrad = ctx.createLinearGradient(centerX - padW / 2, padY, centerX + padW / 2, padY);
     padGrad.addColorStop(0, "#3a3a4a");

--- a/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
+++ b/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
@@ -861,24 +861,43 @@ const FRONT_CLOUDS: SmokeCloud[] = [
   { cx: 0.0, cy: 0.16, scale: 1.4, seed: 0.15 }
 ];
 
-function drawPuffyCloud(ctx: CanvasRenderingContext2D, cx: number, cy: number, radius: number, seed: number) {
-  // Draw a cloud shape using overlapping circles and bezier curves
+function drawPuffyCloud(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  radius: number,
+  seed: number,
+  time: number
+) {
+  // Draw a cloud shape using overlapping circles that churn in place
   const puffs = 5 + Math.floor(seed * 4); // 5-8 puffs per cloud
+  const t = time * 0.001; // convert to seconds
   ctx.beginPath();
 
   for (let i = 0; i < puffs; i++) {
-    const angle = (i / puffs) * Math.PI * 2 + seed * Math.PI;
-    const dist = radius * (0.3 + seed * 0.3 + Math.sin(angle * 2 + seed * 5) * 0.15);
-    const px = cx + Math.cos(angle) * dist;
-    const py = cy + Math.sin(angle) * dist * 0.6; // squash vertically
-    const puffR = radius * (0.5 + Math.sin(i * 2.3 + seed * 7) * 0.2);
+    const puffPhase = seed * 10 + i * 1.7; // unique phase per puff
+
+    // Puffs slowly orbit their base position
+    const baseAngle = (i / puffs) * Math.PI * 2 + seed * Math.PI;
+    const orbitAngle = baseAngle + Math.sin(t * 0.4 + puffPhase) * 0.5;
+    const baseDist = radius * (0.3 + seed * 0.3);
+    const dist = baseDist + Math.sin(t * 0.6 + puffPhase * 1.3) * radius * 0.15;
+
+    const px = cx + Math.cos(orbitAngle) * dist;
+    const py = cy + Math.sin(orbitAngle) * dist * 0.6; // squash vertically
+
+    // Puff size pulses
+    const baseR = radius * (0.45 + seed * 0.1);
+    const puffR = baseR + Math.sin(t * 0.8 + puffPhase * 0.9) * radius * 0.12;
+
     ctx.moveTo(px + puffR, py);
     ctx.arc(px, py, puffR, 0, Math.PI * 2);
   }
 
-  // Central fill puff
-  ctx.moveTo(cx + radius * 0.6, cy);
-  ctx.arc(cx, cy, radius * 0.6, 0, Math.PI * 2);
+  // Central fill puff also breathes
+  const centerR = radius * (0.55 + Math.sin(t * 0.5 + seed * 3) * 0.08);
+  ctx.moveTo(cx + centerR, cy);
+  ctx.arc(cx, cy, centerR, 0, Math.PI * 2);
 
   ctx.fill();
 }
@@ -940,7 +959,7 @@ function drawSmokeLayer(
 
     ctx.fillStyle = grad;
     ctx.globalAlpha = localIntensity;
-    drawPuffyCloud(ctx, cx, cy, radius, cloud.seed);
+    drawPuffyCloud(ctx, cx, cy, radius, cloud.seed, time);
   }
 
   ctx.restore();

--- a/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
+++ b/src/components/ScrollAnimation/scenes/rocketDrawUtils.ts
@@ -414,8 +414,10 @@ export function drawSkyline(
 // ── Rocket Drawing ──
 
 export function getRocketDimensions(width: number, height: number) {
-  const rocketH = height * 0.5;
-  const rocketW = rocketH * 0.18;
+  const baseH = height * 0.5 + 75;
+  const baseW = height * 0.5 * 0.18 + 25;
+  const rocketH = baseH;
+  const rocketW = baseW;
   const centerX = width / 2;
   const noseH = rocketH * 0.2;
   const bodyH = rocketH * 0.55;
@@ -688,9 +690,9 @@ function drawFin(
   finPath.closePath();
 
   const finGrad = ctx.createLinearGradient(x, attachTop, x + side * halfW * 1.8, tipY);
-  finGrad.addColorStop(0, "#cc2929");
-  finGrad.addColorStop(0.5, "#e04040");
-  finGrad.addColorStop(1, "#991f1f");
+  finGrad.addColorStop(0, "#cc6a15");
+  finGrad.addColorStop(0.5, "#e07820");
+  finGrad.addColorStop(1, "#994e0f");
   ctx.fillStyle = finGrad;
   ctx.fill(finPath);
 


### PR DESCRIPTION
## Summary
- Mute skyline building colors to dark grays so they don't compete with the rocket, and ensure each building gets a distinct shade
- Enlarge rocket (+100px height, +50px width) and change fin color from red to burnt orange matching site branding
- Increase smoke opacity for more visible launch effects and lower ignition/launch thresholds

## Test plan
- [x] Verify hero section renders rocket, buildings, and smoke correctly on desktop
- [x] Verify buildings have distinct gray shades and don't merge visually
- [x] Verify rocket fins are orange, not red
- [x] Verify smoke is clearly visible at idle state
- [x] Check mobile responsiveness of the hero canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)