### PR TITLE
Fix blog images overflowing viewport

### DIFF
--- a/src/components/Blog/PostHeader.tsx
+++ b/src/components/Blog/PostHeader.tsx
@@ -31,8 +31,7 @@ const PostHeader = ({ title, tags, date, image }: Props) => {
       )}
       <Box sx={{ textAlign: "center", paddingY: 6 }} component="section">
         <Image
-          style={{ borderRadius: "24px" }}
-          //   layout="responsive"
+          style={{ borderRadius: "24px", maxWidth: "100%", height: "auto" }}
           src={image?.url || ""}
           alt={`Cover image for ${title}`}
           width={1060}

--- a/src/components/RichTextAsset.tsx
+++ b/src/components/RichTextAsset.tsx
@@ -12,8 +12,14 @@ export default function RichTextAsset({ id, assets }: Props) {
 
   if (asset?.url) {
     return (
-      <Box sx={{ marginY: 5 }}>
-        <Image src={asset.url} width={asset.width || 500} height={asset.height || 200} alt={asset?.description || ""} />
+      <Box sx={{ marginY: 5, maxWidth: "100%", height: "auto" }}>
+        <Image
+          src={asset.url}
+          width={asset.width || 500}
+          height={asset.height || 200}
+          alt={asset?.description || ""}
+          style={{ maxWidth: "100%", height: "auto" }}
+        />
       </Box>
     );
   }


### PR DESCRIPTION
## Summary
- Blog post images (embedded rich text assets and cover image) were rendering at native Contentful dimensions, causing horizontal scroll on smaller screens
- Added `max-width: 100%` and `height: auto` to both `RichTextAsset` and `PostHeader` image components so they scale responsively

## Test plan
- [ ] Open a blog post with embedded images (e.g. `/blog/genai-capabilities-and-limitations`)
- [ ] Verify images fit within the page width on desktop
- [ ] Verify images scale down on mobile/tablet viewports with no horizontal scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)